### PR TITLE
Fix runtime contract validation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Or globally in `bootstrap/app.php` (Laravel 11+):
 ```php
 return [
     'failure_mode'   => env('ACCORD_FAILURE_MODE', 'exception'), // exception | log | callable
+    'log_channel'    => env('ACCORD_LOG_CHANNEL'),               // null = default logger
     'failure_callable' => null,
     'version_pattern'  => '/^\/v(\d+)(?:\/|$)/',
     'spec_source'    => env('ACCORD_SPEC_SOURCE', 'file'),       // file | url

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ php artisan vendor:publish --tag=accord-config
 
 ## How it works
 
-Accord extracts the API version from the request URI (`/v1/` → `v1`), loads the corresponding spec file (`resources/openapi/v1.yaml`), and validates request bodies and response bodies against the schemas defined in that spec.
+Accord extracts the API version from the request URI (`/v1/` → `v1`), loads the corresponding spec file (`resources/openapi/v1.yaml`), and validates request parameters, request bodies, and response bodies against the schemas defined in that spec.
 
 Requests and responses with no matching operation, or whose operation defines no schema for the content type, pass silently. Accord only enforces what the spec describes — making it safe to adopt incrementally on existing APIs.
 

--- a/src/ContractValidator.php
+++ b/src/ContractValidator.php
@@ -6,6 +6,8 @@ namespace Fissible\Accord;
 
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Operation;
+use cebe\openapi\spec\Parameter;
+use cebe\openapi\spec\PathItem;
 use cebe\openapi\spec\Schema;
 use Fissible\Accord\Exception\ContractViolationException;
 use JsonSchema\Validator as JsonSchemaValidator;
@@ -42,23 +44,39 @@ class ContractValidator
             return ValidationResult::valid($version);
         }
 
-        $method    = strtolower($request->getMethod());
-        $path      = $request->getUri()->getPath();
-        $operation = $this->findOperation($spec, $method, $path);
+        $method = strtolower($request->getMethod());
+        $path   = $request->getUri()->getPath();
+        $match  = $this->findPathItem($spec, $path);
 
-        if ($operation === null || $operation->requestBody === null) {
+        if ($match === null) {
             return ValidationResult::valid($version);
+        }
+
+        $operation = $match['pathItem']->getOperations()[$method] ?? null;
+
+        if ($operation === null) {
+            return ValidationResult::valid($version);
+        }
+
+        $errors = $this->validateParameters($operation, $match['pathItem'], $match['template'], $request);
+
+        if ($operation->requestBody === null) {
+            return empty($errors)
+                ? ValidationResult::valid($version)
+                : ValidationResult::invalid($errors, $version);
         }
 
         $contentType = $this->parseContentType($request->getHeaderLine('Content-Type'));
         $mediaType   = $operation->requestBody->content[$contentType] ?? null;
 
         if ($mediaType === null || $mediaType->schema === null) {
-            return ValidationResult::valid($version);
+            return empty($errors)
+                ? ValidationResult::valid($version)
+                : ValidationResult::invalid($errors, $version);
         }
 
         $body   = (string) $request->getBody();
-        $errors = $this->validateJsonBody($body, $mediaType->schema);
+        $errors = array_merge($errors, $this->validateJsonBody($body, $mediaType->schema));
 
         return empty($errors)
             ? ValidationResult::valid($version)
@@ -124,9 +142,21 @@ class ContractValidator
 
     private function findOperation(OpenApi $spec, string $method, string $path): ?Operation
     {
+        $match = $this->findPathItem($spec, $path);
+
+        if ($match === null) {
+            return null;
+        }
+
+        return $match['pathItem']->getOperations()[$method] ?? null;
+    }
+
+    /** @return array{template: string, pathItem: PathItem}|null */
+    private function findPathItem(OpenApi $spec, string $path): ?array
+    {
         foreach ($spec->paths as $template => $pathItem) {
-            if ($this->pathMatches($template, $path)) {
-                return $pathItem->getOperations()[$method] ?? null;
+            if ($pathItem instanceof PathItem && $this->pathMatches($template, $path)) {
+                return ['template' => $template, 'pathItem' => $pathItem];
             }
         }
 
@@ -148,15 +178,214 @@ class ContractValidator
     }
 
     /** @return string[] */
+    private function validateParameters(
+        Operation $operation,
+        PathItem $pathItem,
+        string $template,
+        ServerRequestInterface $request,
+    ): array {
+        $errors         = [];
+        $pathParameters = $this->extractPathParameters($template, $request->getUri()->getPath());
+
+        foreach ($this->collectParameters($pathItem, $operation) as $parameter) {
+            if (!$parameter->schema instanceof Schema || !in_array($parameter->in, ['query', 'path', 'header'], true)) {
+                continue;
+            }
+
+            [$present, $rawValue] = $this->parameterValue($parameter, $request, $pathParameters);
+
+            if (!$present) {
+                if ($parameter->required) {
+                    $errors[] = sprintf('Missing required %s parameter "%s"', $parameter->in, $parameter->name);
+                }
+
+                continue;
+            }
+
+            $value  = $this->deserializeParameterValue($parameter, $rawValue);
+            $errors = array_merge($errors, $this->validateParameterValue($parameter, $value));
+        }
+
+        return $errors;
+    }
+
+    /** @return Parameter[] */
+    private function collectParameters(PathItem $pathItem, Operation $operation): array
+    {
+        $parameters = [];
+
+        foreach (array_merge($pathItem->parameters, $operation->parameters) as $parameter) {
+            if (!$parameter instanceof Parameter) {
+                continue;
+            }
+
+            $parameters[$parameter->in . ':' . $parameter->name] = $parameter;
+        }
+
+        return array_values($parameters);
+    }
+
+    /**
+     * @param array<string, string> $pathParameters
+     * @return array{0: bool, 1: mixed}
+     */
+    private function parameterValue(
+        Parameter $parameter,
+        ServerRequestInterface $request,
+        array $pathParameters,
+    ): array {
+        if ($parameter->in === 'path') {
+            return array_key_exists($parameter->name, $pathParameters)
+                ? [true, $pathParameters[$parameter->name]]
+                : [false, null];
+        }
+
+        if ($parameter->in === 'query') {
+            $query = $request->getQueryParams();
+
+            return array_key_exists($parameter->name, $query)
+                ? [true, $query[$parameter->name]]
+                : [false, null];
+        }
+
+        if ($parameter->in === 'header') {
+            return $request->hasHeader($parameter->name)
+                ? [true, $request->getHeaderLine($parameter->name)]
+                : [false, null];
+        }
+
+        return [false, null];
+    }
+
+    private function deserializeParameterValue(Parameter $parameter, mixed $value): mixed
+    {
+        $schema = $parameter->schema;
+
+        if (!$schema instanceof Schema) {
+            return $value;
+        }
+
+        if ($schema->type !== 'array') {
+            return $this->coerceParameterValue($value, $schema);
+        }
+
+        if (!is_array($value)) {
+            $value = $this->splitArrayParameterValue((string) $value, $parameter);
+        }
+
+        $itemSchema = $schema->items instanceof Schema ? $schema->items : null;
+
+        return array_map(
+            fn(mixed $item): mixed => $this->coerceParameterValue($item, $itemSchema),
+            $value,
+        );
+    }
+
+    /** @return string[] */
+    private function splitArrayParameterValue(string $value, Parameter $parameter): array
+    {
+        $separator = match ($parameter->style) {
+            'pipeDelimited'  => '|',
+            'spaceDelimited' => ' ',
+            default          => ',',
+        };
+
+        if ($parameter->style === 'form' && $parameter->explode) {
+            return [$value];
+        }
+
+        return $value === '' ? [] : array_map('trim', explode($separator, $value));
+    }
+
+    private function coerceParameterValue(mixed $value, ?Schema $schema): mixed
+    {
+        if (!$schema instanceof Schema || is_array($value)) {
+            return $value;
+        }
+
+        return match ($schema->type) {
+            'integer' => is_string($value) && preg_match('/^-?\d+$/', $value) ? (int) $value : $value,
+            'number'  => is_string($value) && is_numeric($value) ? (float) $value : $value,
+            'boolean' => $this->coerceBooleanParameterValue($value),
+            'string'  => (string) $value,
+            default   => $value,
+        };
+    }
+
+    private function coerceBooleanParameterValue(mixed $value): mixed
+    {
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        return match (strtolower($value)) {
+            'true', '1'  => true,
+            'false', '0' => false,
+            default      => $value,
+        };
+    }
+
+    /** @return string[] */
+    private function validateParameterValue(Parameter $parameter, mixed $value): array
+    {
+        $schema = $parameter->schema;
+
+        if (!$schema instanceof Schema) {
+            return [];
+        }
+
+        return array_map(
+            fn(string $error): string => sprintf('%s parameter "%s": %s', $parameter->in, $parameter->name, $error),
+            $this->validateJsonValue($value, $schema),
+        );
+    }
+
+    /** @return array<string, string> */
+    private function extractPathParameters(string $template, string $path): array
+    {
+        $parts   = preg_split('/(\{[^}]+\})/', $template, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $names   = [];
+        $pattern = '';
+
+        foreach ($parts ?: [] as $part) {
+            if (preg_match('/^\{([^}]+)\}$/', $part, $matches)) {
+                $names[] = $matches[1];
+                $pattern .= '([^/]+)';
+                continue;
+            }
+
+            $pattern .= preg_quote($part, '#');
+        }
+
+        if (!preg_match('#^' . $pattern . '$#', $path, $matches)) {
+            return [];
+        }
+
+        $parameters = [];
+
+        foreach ($names as $index => $name) {
+            $parameters[$name] = rawurldecode($matches[$index + 1]);
+        }
+
+        return $parameters;
+    }
+
+    /** @return string[] */
     private function validateJsonBody(string $body, Schema $schema): array
     {
         if ($body === '') {
             return [];
         }
 
-        $data      = json_decode($body);
-        $schemaObj = $schema->getSerializableData();
+        $data = json_decode($body);
 
+        return $this->validateJsonValue($data, $schema);
+    }
+
+    /** @return string[] */
+    private function validateJsonValue(mixed $data, Schema $schema): array
+    {
+        $schemaObj = $schema->getSerializableData();
         $validator = new JsonSchemaValidator();
         $validator->validate($data, $schemaObj);
 

--- a/src/ContractValidator.php
+++ b/src/ContractValidator.php
@@ -135,7 +135,14 @@ class ContractValidator
 
     private function pathMatches(string $template, string $path): bool
     {
-        $pattern = preg_replace('/\{[^}]+\}/', '[^/]+', preg_quote($template, '#'));
+        $parts   = preg_split('/(\{[^}]+\})/', $template, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $pattern = '';
+
+        foreach ($parts ?: [] as $part) {
+            $pattern .= preg_match('/^\{[^}]+\}$/', $part)
+                ? '[^/]+'
+                : preg_quote($part, '#');
+        }
 
         return (bool) preg_match('#^' . $pattern . '$#', $path);
     }

--- a/src/Drivers/Laravel/Providers/AccordServiceProvider.php
+++ b/src/Drivers/Laravel/Providers/AccordServiceProvider.php
@@ -12,6 +12,7 @@ use Fissible\Accord\SpecSourceInterface;
 use Fissible\Accord\UrlSpecSource;
 use Fissible\Accord\VersionExtractor;
 use Illuminate\Support\ServiceProvider;
+use Psr\Log\LoggerInterface;
 
 class AccordServiceProvider extends ServiceProvider
 {
@@ -53,6 +54,7 @@ class AccordServiceProvider extends ServiceProvider
                 specSource:       $this->app->make(SpecSourceInterface::class),
                 failureMode:      $failureMode,
                 failureCallable:  $failureCallable,
+                logger:           $this->resolveLogger(),
             );
         });
 
@@ -66,5 +68,16 @@ class AccordServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../config/accord.php' => config_path('accord.php'),
         ], 'accord-config');
+    }
+
+    private function resolveLogger(): LoggerInterface
+    {
+        $channel = config('accord.log_channel');
+
+        if (is_string($channel) && $channel !== '') {
+            return $this->app->make('log')->channel($channel);
+        }
+
+        return $this->app->make(LoggerInterface::class);
     }
 }

--- a/src/Drivers/Laravel/config/accord.php
+++ b/src/Drivers/Laravel/config/accord.php
@@ -12,6 +12,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Log Channel
+    |--------------------------------------------------------------------------
+    | Laravel log channel used when failure_mode is "log". Leave null to use
+    | the application's default PSR logger.
+    |
+    */
+    'log_channel' => env('ACCORD_LOG_CHANNEL'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Failure Callable
     |--------------------------------------------------------------------------
     | Invoked when failure_mode is "callable". Must be a callable resolvable

--- a/tests/Feature/ContractValidatorTest.php
+++ b/tests/Feature/ContractValidatorTest.php
@@ -133,6 +133,33 @@ class ContractValidatorTest extends TestCase
         $this->assertNotEmpty($result->errors);
     }
 
+    public function test_parameterized_path_response_body_is_validated(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = new ServerRequest('GET', '/v1/users/123');
+        $response  = (new Response(200))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(\Nyholm\Psr7\Stream::create('{"id":"not-an-int","name":"Alice"}'));
+
+        $result = $validator->validateResponse($response, $request);
+
+        $this->assertFalse($result->valid);
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public function test_parameterized_path_does_not_match_extra_segments(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = new ServerRequest('GET', '/v1/users/123/extra');
+        $response  = (new Response(200))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(\Nyholm\Psr7\Stream::create('{"id":"not-an-int","name":"Alice"}'));
+
+        $result = $validator->validateResponse($response, $request);
+
+        $this->assertTrue($result->valid);
+    }
+
     // -------------------------------------------------------------------------
     // Failure modes
     // -------------------------------------------------------------------------

--- a/tests/Feature/ContractValidatorTest.php
+++ b/tests/Feature/ContractValidatorTest.php
@@ -86,6 +86,120 @@ class ContractValidatorTest extends TestCase
         $this->assertNotEmpty($result->errors);
     }
 
+    public function test_valid_get_request_parameters_pass(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = (new ServerRequest('GET', '/v1/roster?page=2&status=active'))
+            ->withHeader('X-Client', 'ios');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertTrue($result->valid);
+    }
+
+    public function test_missing_required_query_parameter_fails(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = (new ServerRequest('GET', '/v1/roster?status=active'))
+            ->withHeader('X-Client', 'ios');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertFalse($result->valid);
+        $this->assertContains('Missing required query parameter "page"', $result->errors);
+    }
+
+    public function test_invalid_query_parameter_type_fails(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = (new ServerRequest('GET', '/v1/roster?page=abc'))
+            ->withHeader('X-Client', 'ios');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertFalse($result->valid);
+        $this->assertStringContainsString('query parameter "page"', implode("\n", $result->errors));
+    }
+
+    public function test_invalid_query_parameter_enum_fails(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = (new ServerRequest('GET', '/v1/roster?page=2&status=suspended'))
+            ->withHeader('X-Client', 'ios');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertFalse($result->valid);
+        $this->assertStringContainsString('query parameter "status"', implode("\n", $result->errors));
+    }
+
+    public function test_valid_query_array_parameter_passes(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = (new ServerRequest('GET', '/v1/roster?page=2&ids=1,2,3'))
+            ->withHeader('X-Client', 'ios');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertTrue($result->valid);
+    }
+
+    public function test_invalid_query_array_parameter_item_fails(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = (new ServerRequest('GET', '/v1/roster?page=2&ids=1,nope,3'))
+            ->withHeader('X-Client', 'ios');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertFalse($result->valid);
+        $this->assertStringContainsString('query parameter "ids"', implode("\n", $result->errors));
+    }
+
+    public function test_invalid_header_parameter_fails(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = (new ServerRequest('GET', '/v1/roster?page=2'))
+            ->withHeader('X-Client', 'io');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertFalse($result->valid);
+        $this->assertStringContainsString('header parameter "X-Client"', implode("\n", $result->errors));
+    }
+
+    public function test_missing_required_header_parameter_fails(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = new ServerRequest('GET', '/v1/roster?page=2');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertFalse($result->valid);
+        $this->assertContains('Missing required header parameter "X-Client"', $result->errors);
+    }
+
+    public function test_valid_path_parameter_passes(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = new ServerRequest('GET', '/v1/users/123');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertTrue($result->valid);
+    }
+
+    public function test_invalid_path_parameter_fails(): void
+    {
+        $validator = $this->makeValidator();
+        $request   = new ServerRequest('GET', '/v1/users/not-an-int');
+
+        $result = $validator->validateRequest($request);
+
+        $this->assertFalse($result->valid);
+        $this->assertStringContainsString('path parameter "id"', implode("\n", $result->errors));
+    }
+
     // -------------------------------------------------------------------------
     // Response validation
     // -------------------------------------------------------------------------

--- a/tests/Feature/LaravelServiceProviderTest.php
+++ b/tests/Feature/LaravelServiceProviderTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Support {
+    if (!class_exists(ServiceProvider::class)) {
+        abstract class ServiceProvider
+        {
+            public function __construct(
+                protected mixed $app,
+            ) {}
+
+            protected function mergeConfigFrom(string $path, string $key): void {}
+
+            protected function publishes(array $paths, ?string $group = null): void {}
+        }
+    }
+}
+
+namespace {
+    if (!function_exists('config')) {
+        function config(string $key, mixed $default = null): mixed
+        {
+            return \Fissible\Accord\Tests\Feature\LaravelConfig::get($key, $default);
+        }
+    }
+
+    if (!function_exists('base_path')) {
+        function base_path(string $path = ''): string
+        {
+            $base = dirname(__DIR__);
+
+            return $path === '' ? $base : $base . '/' . ltrim($path, '/');
+        }
+    }
+
+    if (!function_exists('config_path')) {
+        function config_path(string $path = ''): string
+        {
+            $base = dirname(__DIR__) . '/config';
+
+            return $path === '' ? $base : $base . '/' . ltrim($path, '/');
+        }
+    }
+}
+
+namespace Fissible\Accord\Tests\Feature {
+    use Fissible\Accord\ContractValidator;
+    use Fissible\Accord\Drivers\Laravel\Providers\AccordServiceProvider;
+    use Fissible\Accord\ValidationResult;
+    use PHPUnit\Framework\TestCase;
+    use Psr\Log\AbstractLogger;
+    use Psr\Log\LoggerInterface;
+
+    class LaravelServiceProviderTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            LaravelConfig::$values = [
+                'accord.failure_mode'      => 'log',
+                'accord.failure_callable'  => null,
+                'accord.version_pattern'   => '/^\/v(\d+)(?:\/|$)/',
+                'accord.spec_source'       => 'file',
+                'accord.spec_pattern'      => '{base}/Fixtures/{version}',
+                'accord.spec_cache_ttl'    => 3600,
+                'accord.log_channel'       => null,
+            ];
+        }
+
+        public function test_laravel_provider_injects_default_logger(): void
+        {
+            $logger = new RecordingLogger();
+            $app    = new FakeLaravelContainer([
+                LoggerInterface::class => $logger,
+            ]);
+
+            (new AccordServiceProvider($app))->register();
+
+            $validator = $app->make(ContractValidator::class);
+            $validator->handleFailure(ValidationResult::invalid(['something broke'], 'v1'));
+
+            $this->assertCount(1, $logger->records);
+            $this->assertSame('warning', $logger->records[0]['level']);
+            $this->assertSame('API contract violation', $logger->records[0]['message']);
+        }
+
+        public function test_laravel_provider_uses_configured_log_channel(): void
+        {
+            LaravelConfig::$values['accord.log_channel'] = 'accord';
+
+            $logger     = new RecordingLogger();
+            $logManager = new FakeLogManager($logger);
+            $app        = new FakeLaravelContainer([
+                'log' => $logManager,
+            ]);
+
+            (new AccordServiceProvider($app))->register();
+
+            $validator = $app->make(ContractValidator::class);
+            $validator->handleFailure(ValidationResult::invalid(['something broke'], 'v1'));
+
+            $this->assertSame('accord', $logManager->requestedChannel);
+            $this->assertCount(1, $logger->records);
+        }
+    }
+
+    final class LaravelConfig
+    {
+        /** @var array<string, mixed> */
+        public static array $values = [];
+
+        public static function get(string $key, mixed $default = null): mixed
+        {
+            return array_key_exists($key, self::$values)
+                ? self::$values[$key]
+                : $default;
+        }
+    }
+
+    final class FakeLaravelContainer
+    {
+        /** @var array<string, mixed> */
+        private array $instances;
+
+        /** @var array<string, callable(): mixed> */
+        private array $singletons = [];
+
+        /** @param array<string, mixed> $instances */
+        public function __construct(array $instances = [])
+        {
+            $this->instances = $instances;
+        }
+
+        public function singleton(string $abstract, callable $factory): void
+        {
+            $this->singletons[$abstract] = $factory;
+        }
+
+        public function make(string $abstract): mixed
+        {
+            if (array_key_exists($abstract, $this->instances)) {
+                return $this->instances[$abstract];
+            }
+
+            if (array_key_exists($abstract, $this->singletons)) {
+                return $this->instances[$abstract] = ($this->singletons[$abstract])();
+            }
+
+            throw new \RuntimeException("Nothing bound for {$abstract}");
+        }
+    }
+
+    final class FakeLogManager
+    {
+        public ?string $requestedChannel = null;
+
+        public function __construct(
+            private readonly LoggerInterface $logger,
+        ) {}
+
+        public function channel(string $channel): LoggerInterface
+        {
+            $this->requestedChannel = $channel;
+
+            return $this->logger;
+        }
+    }
+
+    final class RecordingLogger extends AbstractLogger
+    {
+        /** @var array<int, array{level: string, message: string, context: array<string, mixed>}> */
+        public array $records = [];
+
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            $this->records[] = [
+                'level'   => (string) $level,
+                'message' => (string) $message,
+                'context' => $context,
+            ];
+        }
+    }
+}

--- a/tests/Fixtures/v1.json
+++ b/tests/Fixtures/v1.json
@@ -5,6 +5,29 @@
         "version": "1"
     },
     "paths": {
+        "/v1/users/{id}": {
+            "get": {
+                "operationId": "users.show",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["id", "name"],
+                                    "properties": {
+                                        "id":   { "type": "integer" },
+                                        "name": { "type": "string"  }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/users": {
             "get": {
                 "operationId": "users.index",

--- a/tests/Fixtures/v1.json
+++ b/tests/Fixtures/v1.json
@@ -5,7 +5,77 @@
         "version": "1"
     },
     "paths": {
+        "/v1/roster": {
+            "get": {
+                "operationId": "roster.index",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "enum": ["active", "inactive"]
+                        }
+                    },
+                    {
+                        "name": "ids",
+                        "in": "query",
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    {
+                        "name": "X-Client",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "minLength": 3
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/users/{id}": {
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ],
             "get": {
                 "operationId": "users.show",
                 "responses": {

--- a/tests/Fixtures/v1.yaml
+++ b/tests/Fixtures/v1.yaml
@@ -3,7 +3,53 @@ info:
   title: Test API
   version: '1'
 paths:
+  /v1/roster:
+    get:
+      operationId: roster.index
+      parameters:
+        - name: page
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum:
+              - active
+              - inactive
+        - name: ids
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: X-Client
+          in: header
+          required: true
+          schema:
+            type: string
+            minLength: 3
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
   /v1/users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
     get:
       operationId: users.show
       responses:

--- a/tests/Fixtures/v1.yaml
+++ b/tests/Fixtures/v1.yaml
@@ -3,6 +3,25 @@ info:
   title: Test API
   version: '1'
 paths:
+  /v1/users/{id}:
+    get:
+      operationId: users.show
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                additionalProperties: false
   /v1/users:
     get:
       operationId: users.index


### PR DESCRIPTION
## Summary

- Fix Laravel log mode so contract violations go to the configured/default Laravel logger instead of `NullLogger`.
- Fix templated OpenAPI path matching for routes like `/v1/users/{id}`.
- Validate schema-backed request parameters for `query`, `path`, and `header`, including required checks, scalar coercion, and basic array parameters.

## Tests

- `vendor/bin/phpunit --colors=never`

## Issues

Closes #2.
Closes #3.
Closes #4.
