### PR TITLE
feat: per-direction failure modes + HTTP-aware rendering (#5, #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Or globally in `bootstrap/app.php` (Laravel 11+):
 return [
     'failure_mode'   => env('ACCORD_FAILURE_MODE', 'exception'), // exception | log | callable
     'log_channel'    => env('ACCORD_LOG_CHANNEL'),               // null = default logger
+    'request_violation_status' => env('ACCORD_REQUEST_VIOLATION_STATUS', 422), // request 4xx; non-4xx → 422
     'failure_callable' => null,
     'version_pattern'  => '/^\/v(\d+)(?:\/|$)/',
     'spec_source'    => env('ACCORD_SPEC_SOURCE', 'file'),       // file | url
@@ -287,6 +288,19 @@ return [
     'spec_cache_ttl' => env('ACCORD_SPEC_CACHE_TTL', 3600),
 ];
 ```
+
+**Per-direction failure modes.** `failure_mode` may be a single value applied to both
+directions, or an array with separate `request` and `response` modes:
+
+```php
+'failure_mode' => ['request' => 'exception', 'response' => 'log'],
+```
+
+In the Laravel driver, a **request** violation under `exception` mode is rendered as a JSON
+response (`{ "message": ..., "errors": [...] }`) with `request_violation_status` (default
+`422`; a non-4xx value falls back to `422`). A **response** violation is treated as a
+server-side problem: under `exception` mode it surfaces as a 500, and under `log` mode it is
+logged while the original response passes through unchanged — it is never rendered as a 4xx.
 
 ### Loading specs from a URL
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "symfony/yaml": "^6.0|^7.0"
     },
     "require-dev": {
+        "illuminate/http": "^10.0|^11.0|^12.0",
         "phpunit/phpunit": "^11.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "8.2.0"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "181d92d0a1cc3e35723a433838b19d91",
+    "content-hash": "e03838f62eadf7876085da335baad67f",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -77,16 +77,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "v6.7.2",
+            "version": "6.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0"
+                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/6fea66c7204683af437864e7c4e7abf383d14bc0",
-                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/bd1bda2ebfc8bff418565941771ea8f03c557886",
+                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886",
                 "shasum": ""
             },
             "require": {
@@ -146,9 +146,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/v6.7.2"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.9.0"
             },
-            "time": "2026-02-15T15:06:22+00:00"
+            "time": "2026-06-05T14:05:24+00:00"
         },
         {
             "name": "marc-mabe/php-enum",
@@ -625,16 +625,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -647,7 +647,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -672,7 +672,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -684,24 +684,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.7",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81"
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
-                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
                 "shasum": ""
             },
             "require": {
@@ -750,7 +754,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.7"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -770,20 +774,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T13:15:18+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -833,7 +837,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -853,20 +857,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -918,7 +922,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -938,20 +942,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/psr-http-message-bridge.git",
-                "reference": "929ffe10bbfbb92e711ac3818d416f9daffee067"
+                "reference": "76f1a57719a4a04c0ea18678a6c9305b5dcb9da8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/929ffe10bbfbb92e711ac3818d416f9daffee067",
-                "reference": "929ffe10bbfbb92e711ac3818d416f9daffee067",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/76f1a57719a4a04c0ea18678a6c9305b5dcb9da8",
+                "reference": "76f1a57719a4a04c0ea18678a6c9305b5dcb9da8",
                 "shasum": ""
             },
             "require": {
@@ -1006,7 +1010,7 @@
                 "psr-7"
             ],
             "support": {
-                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v7.4.4"
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -1026,20 +1030,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-03T23:30:35+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.6",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391"
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/58751048de17bae71c5aa0d13cb19d79bca26391",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
                 "shasum": ""
             },
             "require": {
@@ -1082,7 +1086,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.6"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -1102,7 +1106,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T09:33:46+00:00"
+            "time": "2026-05-25T06:06:12+00:00"
         }
     ],
     "packages-dev": [
@@ -4355,21 +4359,22 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v8.1.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
-                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "psr/clock": "^1.0"
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "symfony/polyfill-php83": "^1.28"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -4408,7 +4413,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v8.1.0"
+                "source": "https://github.com/symfony/clock/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4428,36 +4433,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v8.1.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "d8aeb1abd3fef84795567850d3a567bdb5945ee5"
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/d8aeb1abd3fef84795567850d3a567bdb5945ee5",
-                "reference": "d8aeb1abd3fef84795567850d3a567bdb5945ee5",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
+                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
+                "php": ">=8.2",
                 "psr/log": "^1|^2|^3",
                 "symfony/polyfill-php85": "^1.32",
-                "symfony/var-dumper": "^7.4|^8.0"
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "conflict": {
-                "symfony/deprecation-contracts": "<2.5"
+                "symfony/deprecation-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^7.4|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/serializer": "^7.4|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
                 "symfony/webpack-encore-bundle": "^1.0|^2.0"
             },
             "bin": [
@@ -4489,7 +4495,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v8.1.0"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4509,29 +4515,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.1.0",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.2",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/security-http": "<7.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -4540,14 +4545,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
-                "symfony/error-handler": "^7.4|^8.0",
-                "symfony/expression-language": "^7.4|^8.0",
-                "symfony/framework-bundle": "^7.4|^8.0",
-                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^7.4|^8.0"
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4575,7 +4580,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -4595,7 +4600,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -5451,27 +5456,34 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v8.1.0",
+            "version": "v7.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
+                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/ada7578c30dd5feaa8259cff3e885069ea81ddde",
+                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/polyfill-mbstring": "^1.0",
-                "symfony/translation-contracts": "^3.6.1"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.5.3|^3.3"
             },
             "conflict": {
                 "nikic/php-parser": "<5.0",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/service-contracts": "<2.5"
+                "symfony/http-kernel": "<6.4",
+                "symfony/service-contracts": "<2.5",
+                "symfony/twig-bundle": "<6.4",
+                "symfony/yaml": "<6.4"
             },
             "provide": {
                 "symfony/translation-implementation": "2.3|3.0"
@@ -5479,17 +5491,17 @@
             "require-dev": {
                 "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/console": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
-                "symfony/finder": "^7.4|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^7.4|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^7.4|^8.0"
+                "symfony/yaml": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5520,7 +5532,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.1.0"
+                "source": "https://github.com/symfony/translation/tree/v7.4.10"
             },
             "funding": [
                 {
@@ -5540,7 +5552,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-05-06T11:19:24+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -5626,31 +5638,31 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v8.1.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e"
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
-                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/polyfill-mbstring": "^1.0"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/console": "<7.4",
-                "symfony/error-handler": "<7.4"
+                "symfony/console": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^7.4|^8.0",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/process": "^7.4|^8.0",
-                "symfony/uid": "^7.4|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
                 "twig/twig": "^3.12"
             },
             "bin": [
@@ -5689,7 +5701,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v8.1.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -5709,7 +5721,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-03-30T13:44:50+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5845,5 +5857,8 @@
         "php": "^8.2"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.2.0"
+    },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "027e026a34bd69763126d05ef2b6b2f6",
+    "content-hash": "181d92d0a1cc3e35723a433838b19d91",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -1107,6 +1107,1170 @@
     ],
     "packages-dev": [
         {
+            "name": "carbonphp/carbon-doctrine-types",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon-doctrine-types.git",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<4.0.0 || >=5.0.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^4.0.0",
+                "nesbot/carbon": "^2.71.0 || ^3.0.0",
+                "phpunit/phpunit": "^10.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\Doctrine\\": "src/Carbon/Doctrine/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KyleKatarn",
+                    "email": "kylekatarnls@gmail.com"
+                }
+            ],
+            "description": "Types to use Carbon in Doctrine",
+            "keywords": [
+                "carbon",
+                "date",
+                "datetime",
+                "doctrine",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/CarbonPHP/carbon-doctrine-types/issues",
+                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0 || ^13.0",
+                "phpstan/phpstan": "^1.12 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
+                "phpstan/phpstan-strict-rules": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^8.5 || ^12.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Inflector\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
+            "keywords": [
+                "inflection",
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/inflector/issues",
+                "source": "https://github.com/doctrine/inflector/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T19:31:58+00:00"
+        },
+        {
+            "name": "fruitcake/php-cors",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruitcake/php-cors.git",
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruitcake/php-cors/zipball/38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^9",
+                "squizlabs/php_codesniffer": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fruitcake\\Cors\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fruitcake",
+                    "homepage": "https://fruitcake.nl"
+                },
+                {
+                    "name": "Barryvdh",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Cross-origin resource sharing library for the Symfony HttpFoundation",
+            "homepage": "https://github.com/fruitcake/php-cors",
+            "keywords": [
+                "cors",
+                "laravel",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/fruitcake/php-cors/issues",
+                "source": "https://github.com/fruitcake/php-cors/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-03T09:33:47+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.11",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-07T22:54:06+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-02T12:23:43+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-02T12:30:48+00:00"
+        },
+        {
+            "name": "guzzlehttp/uri-template",
+            "version": "v1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/uri-template.git",
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
+                "uri-template/tests": "1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\UriTemplate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                }
+            ],
+            "description": "A polyfill class for uri_template of PHP",
+            "keywords": [
+                "guzzlehttp",
+                "uri-template"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/uri-template/issues",
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/uri-template",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-12T21:33:43+00:00"
+        },
+        {
+            "name": "illuminate/collections",
+            "version": "v12.62.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/collections.git",
+                "reference": "83313b009c4afb6f02dbc090bdb67809756eefa2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/83313b009c4afb6f02dbc090bdb67809756eefa2",
+                "reference": "83313b009c4afb6f02dbc090bdb67809756eefa2",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/conditionable": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "php": "^8.2",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/polyfill-php85": "^1.33"
+            },
+            "suggest": {
+                "illuminate/http": "Required to convert collections to API resources (^12.0).",
+                "symfony/var-dumper": "Required to use the dump method (^7.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php",
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Collections package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-11T14:13:25+00:00"
+        },
+        {
+            "name": "illuminate/conditionable",
+            "version": "v12.62.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/conditionable.git",
+                "reference": "ec677967c1f2faf90b8428919124d2184a4c9b49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/ec677967c1f2faf90b8428919124d2184a4c9b49",
+                "reference": "ec677967c1f2faf90b8428919124d2184a4c9b49",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Conditionable package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2025-05-13T15:08:45+00:00"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v12.62.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "c16fd7ba7d8e6b8f336639ceb6b7e1ff6ed0efb5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/c16fd7ba7d8e6b8f336639ceb6b7e1ff6ed0efb5",
+                "reference": "c16fd7ba7d8e6b8f336639ceb6b7e1ff6ed0efb5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "psr/container": "^1.1.1|^2.0.1",
+                "psr/simple-cache": "^1.0|^2.0|^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Contracts\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Contracts package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-06-09T13:20:54+00:00"
+        },
+        {
+            "name": "illuminate/filesystem",
+            "version": "v12.62.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/filesystem.git",
+                "reference": "3b5ad9b385595d735689ebc2bfe701567cc4f1c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/3b5ad9b385595d735689ebc2bfe701567cc4f1c3",
+                "reference": "3b5ad9b385595d735689ebc2bfe701567cc4f1c3",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2",
+                "symfony/finder": "^7.2.0"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required to use the Filesystem class.",
+                "ext-ftp": "Required to use the Flysystem FTP driver.",
+                "ext-hash": "Required to use the Filesystem class.",
+                "illuminate/http": "Required for handling uploaded files (^12.0).",
+                "league/flysystem": "Required to use the Flysystem local driver (^3.25.1).",
+                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",
+                "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.25.1).",
+                "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.25.1).",
+                "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
+                "symfony/filesystem": "Required to enable support for relative symbolic links (^7.2).",
+                "symfony/mime": "Required to enable support for guessing extensions (^7.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Filesystem package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-06-02T13:54:37+00:00"
+        },
+        {
+            "name": "illuminate/http",
+            "version": "v12.62.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/http.git",
+                "reference": "15f6ff6d3cc237500575827c3d106c63ceb48984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/http/zipball/15f6ff6d3cc237500575827c3d106c63ceb48984",
+                "reference": "15f6ff6d3cc237500575827c3d106c63ceb48984",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "fruitcake/php-cors": "^1.3",
+                "guzzlehttp/guzzle": "^7.8.2",
+                "guzzlehttp/uri-template": "^1.0",
+                "illuminate/collections": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/session": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2",
+                "symfony/http-foundation": "^7.2.0",
+                "symfony/http-kernel": "^7.2.0",
+                "symfony/mime": "^7.2.0",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/polyfill-php85": "^1.33"
+            },
+            "suggest": {
+                "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image()."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Http\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Http package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-05-27T23:28:12+00:00"
+        },
+        {
+            "name": "illuminate/macroable",
+            "version": "v12.62.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/macroable.git",
+                "reference": "e295d62d89dcdb87e2b1bd70dd14d074a0ed73cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/macroable/zipball/e295d62d89dcdb87e2b1bd70dd14d074a0ed73cc",
+                "reference": "e295d62d89dcdb87e2b1bd70dd14d074a0ed73cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Macroable package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-03-30T19:05:19+00:00"
+        },
+        {
+            "name": "illuminate/reflection",
+            "version": "v12.62.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/reflection.git",
+                "reference": "348cf5da9de89b596d7723be6425fb048e2bf4bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/reflection/zipball/348cf5da9de89b596d7723be6425fb048e2bf4bb",
+                "reference": "348cf5da9de89b596d7723be6425fb048e2bf4bb",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "php": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Reflection package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-25T15:25:18+00:00"
+        },
+        {
+            "name": "illuminate/session",
+            "version": "v12.62.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/session.git",
+                "reference": "98802e67dd5e059c0b978b3fe8f5f0a3ac17ec4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/session/zipball/98802e67dd5e059c0b978b3fe8f5f0a3ac17ec4e",
+                "reference": "98802e67dd5e059c0b978b3fe8f5f0a3ac17ec4e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-session": "*",
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/filesystem": "^12.0",
+                "illuminate/support": "^12.0",
+                "php": "^8.2",
+                "symfony/finder": "^7.2.0",
+                "symfony/http-foundation": "^7.2.0"
+            },
+            "suggest": {
+                "illuminate/console": "Required to use the session:table command (^12.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Session\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Session package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-02-14T23:03:41+00:00"
+        },
+        {
+            "name": "illuminate/support",
+            "version": "v12.62.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/support.git",
+                "reference": "3a8772095ef7d6b1961a77f2f0b8921c056c48ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/3a8772095ef7d6b1961a77f2f0b8921c056c48ea",
+                "reference": "3a8772095ef7d6b1961a77f2f0b8921c056c48ea",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^2.0",
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-mbstring": "*",
+                "illuminate/collections": "^12.0",
+                "illuminate/conditionable": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
+                "illuminate/reflection": "^12.0",
+                "nesbot/carbon": "^3.8.4",
+                "php": "^8.2",
+                "symfony/polyfill-php83": "^1.33",
+                "symfony/polyfill-php85": "^1.33",
+                "voku/portable-ascii": "^2.0.2"
+            },
+            "conflict": {
+                "tightenco/collect": "<5.5.33"
+            },
+            "replace": {
+                "spatie/once": "*"
+            },
+            "suggest": {
+                "illuminate/filesystem": "Required to use the Composer class (^12.0).",
+                "laravel/serializable-closure": "Required to use the once function (^1.3|^2.0).",
+                "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.7).",
+                "league/uri": "Required to use the Uri class (^7.5.1).",
+                "ramsey/uuid": "Required to use Str::uuid() (^4.7).",
+                "symfony/process": "Required to use the Composer class (^7.2).",
+                "symfony/uid": "Required to use Str::ulid() (^7.2).",
+                "symfony/var-dumper": "Required to use the dd function (^7.2).",
+                "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.6.1)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php",
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Support package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-05-31T22:10:17+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -1165,6 +2329,111 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nesbot/carbon",
+            "version": "3.12.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon.git",
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6e7853a668c3107294aff38d42bf760ec02126b6",
+                "reference": "6e7853a668c3107294aff38d42bf760ec02126b6",
+                "shasum": ""
+            },
+            "require": {
+                "carbonphp/carbon-doctrine-types": "<100.0",
+                "ext-json": "*",
+                "php": "^8.1",
+                "psr/clock": "^1.0",
+                "symfony/clock": "^6.3.12 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6.3 || ^4.0",
+                "doctrine/orm": "^2.15.2 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^v3.87.1",
+                "kylekatarnls/multi-tester": "^2.5.3",
+                "phpmd/phpmd": "^2.15.0",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.22",
+                "phpunit/phpunit": "^10.5.53",
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0.0"
+            },
+            "bin": [
+                "bin/carbon"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Carbon\\Laravel\\ServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev",
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\": "src/Carbon/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "https://markido.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "https://github.com/kylekatarnls"
+                }
+            ],
+            "description": "An API extension for DateTime that supports 281 different languages.",
+            "homepage": "https://carbonphp.github.io/carbon/",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "docs": "https://carbonphp.github.io/carbon/guide/getting-started/introduction.html",
+                "issues": "https://github.com/CarbonPHP/carbon/issues",
+                "source": "https://github.com/CarbonPHP/carbon"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon#sponsor",
+                    "type": "opencollective"
+                },
+                {
+                    "url": "https://tidelift.com/subscription/pkg/packagist-nesbot-carbon?utm_source=packagist-nesbot-carbon&utm_medium=referral&utm_campaign=readme",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-14T20:41:42+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1798,6 +3067,253 @@
                 }
             ],
             "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2838,6 +4354,1364 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/clock",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/clock.git",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/now.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Clock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Decouples applications from the system clock",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clock",
+                "psr20",
+                "time"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/error-handler",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/error-handler.git",
+                "reference": "d8aeb1abd3fef84795567850d3a567bdb5945ee5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/d8aeb1abd3fef84795567850d3a567bdb5945ee5",
+                "reference": "d8aeb1abd3fef84795567850d3a567bdb5945ee5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/polyfill-php85": "^1.32",
+                "symfony/var-dumper": "^7.4|^8.0"
+            },
+            "conflict": {
+                "symfony/deprecation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0",
+                "symfony/webpack-encore-bundle": "^1.0|^2.0"
+            },
+            "bin": [
+                "Resources/bin/patch-type-declarations"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ErrorHandler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to manage errors and ease debugging PHP code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/error-handler/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/security-http": "<7.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-kernel.git",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^7.3|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/browser-kit": "<6.4",
+                "symfony/cache": "<6.4",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/doctrine-bridge": "<6.4",
+                "symfony/flex": "<2.10",
+                "symfony/form": "<6.4",
+                "symfony/http-client": "<6.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/mailer": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/translation": "<6.4",
+                "symfony/translation-contracts": "<2.5",
+                "symfony/twig-bridge": "<6.4",
+                "symfony/validator": "<6.4",
+                "symfony/var-dumper": "<6.4",
+                "twig/twig": "<3.12"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/css-selector": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
+                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/http-client-contracts": "^2.5|^3",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^7.1|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^7.1|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0",
+                "twig/twig": "^3.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpKernel\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a structured process for converting a Request into a Response",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T08:31:43+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/mailer": "<6.4",
+                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-23T16:22:37+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T15:22:23+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:51:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php84",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:51:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php85",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php85.git",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php85\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.5+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T02:25:22+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation-contracts": "^3.6.1"
+            },
+            "conflict": {
+                "nikic/php-parser": "<5.0",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3|3.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/http-client-contracts": "^2.5|^3.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/routing": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
+                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "symfony/console": "<7.4",
+                "symfony/error-handler": "<7.4"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "twig/twig": "^3.12"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.3.1",
             "source": {
@@ -2886,6 +5760,80 @@
                 }
             ],
             "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "voku/portable-ascii",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/voku/portable-ascii.git",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
+            },
+            "suggest": {
+                "ext-intl": "Use Intl for transliterator_transliterate() support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "voku\\": "src/voku/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Moelleken",
+                    "homepage": "https://www.moelleken.org/"
+                }
+            ],
+            "description": "Portable ASCII library - performance optimized (ascii) string functions for php.",
+            "homepage": "https://github.com/voku/portable-ascii",
+            "keywords": [
+                "ascii",
+                "clean",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/voku/portable-ascii/issues",
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/portable-ascii",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/voku/portable-ascii",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-26T05:33:54+00:00"
         }
     ],
     "aliases": [],

--- a/docs/superpowers/plans/2026-06-14-per-direction-failure-modes-and-rendering.md
+++ b/docs/superpowers/plans/2026-06-14-per-direction-failure-modes-and-rendering.md
@@ -1,0 +1,1332 @@
+# Per-Direction Failure Modes + HTTP-Aware Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let accord apply different failure modes to request vs response contract violations, and render request violations as a proper Laravel 4xx (default 422) instead of a 500 — while a bad response stays a server error.
+
+**Architecture:** A new `Direction` enum flows from the middlewares into `ContractValidator::handleFailure`, which selects request- or response-specific `FailureMode`. The core stays framework-agnostic; the `ContractViolationException` carries only `direction`, and the Laravel `ValidateApiContract` middleware maps a request-direction violation to a `JsonResponse`. Config accepts a string (both directions) or an array (`['request'=>..,'response'=>..]`), parsed by one shared `FailureMode::resolvePair`.
+
+**Tech Stack:** PHP 8.2+, PHPUnit 11, cebe/php-openapi, nyholm/psr7, symfony/psr-http-message-bridge, illuminate/http (added as a dev dependency for the Laravel middleware tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-14-per-direction-failure-modes-and-rendering-design.md`
+
+**Branch:** `feat/per-direction-failure-modes` (already checked out).
+
+**Conventions to honor:** `declare(strict_types=1)` on every file; no `public` properties except readonly promoted constructor props; framework code only under `src/Drivers/`. Run the suite with `vendor/bin/phpunit --colors=never`. Baseline is **60 tests passing, 5 pre-existing deprecations** — do not introduce new deprecations.
+
+---
+
+## File Structure
+
+**Core (create):**
+- `src/Direction.php` — `Request | Response` string-backed enum.
+
+**Core (modify):**
+- `src/FailureMode.php` — add static `resolvePair(string|array|null)`.
+- `src/Exception/ContractViolationException.php` — add trailing `Direction $direction` param.
+- `src/ContractValidator.php` — add `?FailureMode $responseFailureMode`, direction-aware `handleFailure`, `direction` in log context.
+- `src/AccordMiddleware.php` — pass `Direction::Request` / `Direction::Response`.
+- `src/AccordFactory.php` — parse failure mode via `resolvePair`.
+
+**Laravel driver (modify):**
+- `src/Drivers/Laravel/config/accord.php` — add `request_violation_status`; document array `failure_mode`.
+- `src/Drivers/Laravel/Http/Middleware/ValidateApiContract.php` — direction-aware calls + render request violations.
+- `src/Drivers/Laravel/Providers/AccordServiceProvider.php` — wire `resolvePair`, bind `ValidateApiContract` with the status guard.
+
+**Tests (create):**
+- `tests/Support/RecordingLogger.php` — shared PSR-3 recording double.
+- `tests/Unit/DirectionTest.php`
+- `tests/Unit/ContractViolationExceptionTest.php`
+- `tests/Feature/AccordMiddlewareTest.php`
+- `tests/Feature/LaravelMiddlewareTest.php` — needs illuminate/http.
+
+**Tests (modify):**
+- `tests/Unit/FailureModeTest.php` — create (no FailureMode test exists today).
+- `tests/Feature/ContractValidatorTest.php` — add per-direction handleFailure tests.
+- `tests/Feature/LaravelServiceProviderTest.php` — add array-config + binding tests.
+- `tests/Unit/AccordFactoryTest.php` — add array-config regression tests.
+
+**Other (modify):**
+- `composer.json` — add `illuminate/http` to `require-dev`.
+- `README.md` — document array config, `request_violation_status`, rendering behavior.
+
+---
+
+## Task 1: `Direction` enum
+
+**Files:**
+- Create: `src/Direction.php`
+- Test: `tests/Unit/DirectionTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Unit;
+
+use Fissible\Accord\Direction;
+use PHPUnit\Framework\TestCase;
+
+class DirectionTest extends TestCase
+{
+    public function test_backing_values_are_stable_strings(): void
+    {
+        $this->assertSame('request', Direction::Request->value);
+        $this->assertSame('response', Direction::Response->value);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter DirectionTest`
+Expected: FAIL — `Error: Class "Fissible\Accord\Direction" not found`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord;
+
+enum Direction: string
+{
+    case Request  = 'request';
+    case Response = 'response';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter DirectionTest`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Direction.php tests/Unit/DirectionTest.php
+git commit -m "feat: add Direction enum for request/response failure routing
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Shared `RecordingLogger` test double
+
+This is test infrastructure (no behavior to test). Tasks 5, 8, and the middleware tests use it.
+
+**Files:**
+- Create: `tests/Support/RecordingLogger.php`
+
+- [ ] **Step 1: Create the double**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Support;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+final class RecordingLogger extends AbstractLogger
+{
+    /** @var array<int, array{level: string, message: string, context: array<string, mixed>}> */
+    public array $records = [];
+
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level'   => (string) $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+}
+```
+
+Note: `autoload-dev` already maps `Fissible\Accord\Tests\` → `tests/`, so this resolves as `Fissible\Accord\Tests\Support\RecordingLogger` with no `composer dump-autoload` needed. `tests/Support` is not a registered PHPUnit suite, so it is not collected as tests.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/Support/RecordingLogger.php
+git commit -m "test: add shared RecordingLogger PSR-3 double
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `FailureMode::resolvePair`
+
+**Files:**
+- Create: `tests/Unit/FailureModeTest.php`
+- Modify: `src/FailureMode.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Unit;
+
+use Fissible\Accord\FailureMode;
+use PHPUnit\Framework\TestCase;
+use ValueError;
+
+class FailureModeTest extends TestCase
+{
+    public function test_scalar_applies_to_both_directions(): void
+    {
+        $this->assertSame([FailureMode::Log, FailureMode::Log], FailureMode::resolvePair('log'));
+    }
+
+    public function test_full_array_maps_each_direction(): void
+    {
+        $this->assertSame(
+            [FailureMode::Exception, FailureMode::Log],
+            FailureMode::resolvePair(['request' => 'exception', 'response' => 'log']),
+        );
+    }
+
+    public function test_missing_response_key_falls_back_to_request(): void
+    {
+        $this->assertSame(
+            [FailureMode::Log, FailureMode::Log],
+            FailureMode::resolvePair(['request' => 'log']),
+        );
+    }
+
+    public function test_missing_request_key_falls_back_to_exception_default(): void
+    {
+        $this->assertSame(
+            [FailureMode::Exception, FailureMode::Log],
+            FailureMode::resolvePair(['response' => 'log']),
+        );
+    }
+
+    public function test_empty_array_falls_back_to_exception(): void
+    {
+        $this->assertSame(
+            [FailureMode::Exception, FailureMode::Exception],
+            FailureMode::resolvePair([]),
+        );
+    }
+
+    public function test_null_falls_back_to_exception(): void
+    {
+        $this->assertSame(
+            [FailureMode::Exception, FailureMode::Exception],
+            FailureMode::resolvePair(null),
+        );
+    }
+
+    public function test_unknown_scalar_throws(): void
+    {
+        $this->expectException(ValueError::class);
+        FailureMode::resolvePair('bogus');
+    }
+
+    public function test_blank_scalar_throws(): void
+    {
+        $this->expectException(ValueError::class);
+        FailureMode::resolvePair('');
+    }
+
+    public function test_present_but_unknown_array_value_throws(): void
+    {
+        $this->expectException(ValueError::class);
+        FailureMode::resolvePair(['request' => 'nope']);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter FailureModeTest`
+Expected: FAIL — `Error: Call to undefined method Fissible\Accord\FailureMode::resolvePair()`.
+
+- [ ] **Step 3: Implement `resolvePair`**
+
+Replace the entire contents of `src/FailureMode.php` with:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord;
+
+enum FailureMode: string
+{
+    case Exception = 'exception';
+    case Log       = 'log';
+    case Callable  = 'callable';
+
+    /**
+     * Resolve a string|array failure-mode config into [request, response] modes.
+     *
+     * - A scalar string applies to both directions.
+     * - An array may set 'request' and/or 'response'; a MISSING key falls back
+     *   (response → request, request → Exception default).
+     * - null / [] fall back to Exception for both.
+     * - A present-but-unknown string (scalar or array value) throws ValueError
+     *   via self::from — typos are never silently swallowed.
+     *
+     * @param string|array<string, string>|null $config
+     * @return array{0: FailureMode, 1: FailureMode}
+     */
+    public static function resolvePair(string|array|null $config): array
+    {
+        if ($config === null) {
+            return [self::Exception, self::Exception];
+        }
+
+        if (is_array($config)) {
+            $request  = isset($config['request'])  ? self::from($config['request'])  : self::Exception;
+            $response = isset($config['response']) ? self::from($config['response']) : $request;
+
+            return [$request, $response];
+        }
+
+        $mode = self::from($config);
+
+        return [$mode, $mode];
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit --filter FailureModeTest`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/FailureMode.php tests/Unit/FailureModeTest.php
+git commit -m "feat: add FailureMode::resolvePair for string|array config (#5)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `ContractViolationException` carries direction (ABI-preserving)
+
+**Files:**
+- Create: `tests/Unit/ContractViolationExceptionTest.php`
+- Modify: `src/Exception/ContractViolationException.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Unit;
+
+use Fissible\Accord\Direction;
+use Fissible\Accord\Exception\ContractViolationException;
+use Fissible\Accord\ValidationResult;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ContractViolationExceptionTest extends TestCase
+{
+    public function test_defaults_to_request_direction(): void
+    {
+        $e = new ContractViolationException(ValidationResult::invalid(['x'], 'v1'));
+
+        $this->assertSame(Direction::Request, $e->direction);
+    }
+
+    public function test_carries_supplied_direction(): void
+    {
+        $e = new ContractViolationException(
+            ValidationResult::invalid(['x'], 'v1'),
+            direction: Direction::Response,
+        );
+
+        $this->assertSame(Direction::Response, $e->direction);
+    }
+
+    public function test_preserves_legacy_positional_abi(): void
+    {
+        $previous = new RuntimeException('root');
+
+        $e = new ContractViolationException(
+            ValidationResult::invalid(['x'], 'v1'),
+            'custom message',
+            42,
+            $previous,
+        );
+
+        $this->assertSame('custom message', $e->getMessage());
+        $this->assertSame(42, $e->getCode());
+        $this->assertSame($previous, $e->getPrevious());
+        $this->assertSame(Direction::Request, $e->direction);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter ContractViolationExceptionTest`
+Expected: FAIL — `Error: Undefined property ... $direction` (the property does not exist yet).
+
+- [ ] **Step 3: Add the trailing `direction` parameter**
+
+Replace the entire contents of `src/Exception/ContractViolationException.php` with:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Exception;
+
+use Fissible\Accord\Direction;
+use Fissible\Accord\ValidationResult;
+use RuntimeException;
+
+class ContractViolationException extends RuntimeException
+{
+    public function __construct(
+        public readonly ValidationResult $result,
+        string $message = '',
+        int $code = 0,
+        ?\Throwable $previous = null,
+        public readonly Direction $direction = Direction::Request,
+    ) {
+        parent::__construct(
+            $message ?: sprintf(
+                'API contract violation for version %s: %s',
+                $result->version,
+                implode('; ', $result->errors),
+            ),
+            $code,
+            $previous,
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit --filter ContractViolationExceptionTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Exception/ContractViolationException.php tests/Unit/ContractViolationExceptionTest.php
+git commit -m "feat: ContractViolationException carries Direction (trailing param, ABI preserved) (#5)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `ContractValidator` — direction-aware failure handling
+
+**Files:**
+- Modify: `src/ContractValidator.php` (constructor + `handleFailure`)
+- Test: `tests/Feature/ContractValidatorTest.php` (add tests in the "Failure modes" section)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these imports at the top of `tests/Feature/ContractValidatorTest.php` (after the existing `use` block):
+
+```php
+use Fissible\Accord\Direction;
+use Fissible\Accord\Tests\Support\RecordingLogger;
+```
+
+Add these methods inside `class ContractValidatorTest` (e.g. just below the existing `makeValidator` helper):
+
+```php
+    private function makeDirectionalValidator(
+        FailureMode $request,
+        FailureMode $response,
+        RecordingLogger $logger,
+    ): ContractValidator {
+        return new ContractValidator(
+            versionExtractor:    $this->versionExtractor,
+            specSource:          new FileSpecSource($this->fixturesPath, '{base}/{version}'),
+            failureMode:         $request,
+            failureCallable:     null,
+            logger:              $logger,
+            responseFailureMode: $response,
+        );
+    }
+
+    public function test_request_direction_uses_request_mode_and_throws(): void
+    {
+        $validator = $this->makeDirectionalValidator(FailureMode::Exception, FailureMode::Log, new RecordingLogger());
+
+        $this->expectException(ContractViolationException::class);
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Request);
+    }
+
+    public function test_response_direction_uses_response_mode_and_logs(): void
+    {
+        $logger    = new RecordingLogger();
+        $validator = $this->makeDirectionalValidator(FailureMode::Exception, FailureMode::Log, $logger);
+
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
+
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('warning', $logger->records[0]['level']);
+    }
+
+    public function test_log_context_includes_direction(): void
+    {
+        $logger    = new RecordingLogger();
+        $validator = $this->makeDirectionalValidator(FailureMode::Log, FailureMode::Log, $logger);
+
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
+
+        $this->assertSame('response', $logger->records[0]['context']['direction']);
+    }
+
+    public function test_scalar_config_uses_same_mode_for_response_backward_compat(): void
+    {
+        // responseFailureMode null → response falls back to the single failureMode (Log).
+        $logger    = new RecordingLogger();
+        $validator = new ContractValidator(
+            versionExtractor: $this->versionExtractor,
+            specSource:       new FileSpecSource($this->fixturesPath, '{base}/{version}'),
+            failureMode:      FailureMode::Log,
+            failureCallable:  null,
+            logger:           $logger,
+        );
+
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
+
+        $this->assertCount(1, $logger->records);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter ContractValidatorTest`
+Expected: FAIL — `handleFailure` does not accept a second argument / `responseFailureMode` is not a known named parameter.
+
+- [ ] **Step 3: Update the constructor and `handleFailure`**
+
+In `src/ContractValidator.php`, change the constructor to add the trailing param (leave the existing five params unchanged):
+
+```php
+    public function __construct(
+        private readonly VersionExtractor $versionExtractor,
+        private readonly SpecSourceInterface $specSource,
+        private readonly FailureMode $failureMode = FailureMode::Exception,
+        /** @var callable(ValidationResult): void|null */
+        private readonly mixed $failureCallable = null,
+        private readonly LoggerInterface $logger = new NullLogger(),
+        private readonly ?FailureMode $responseFailureMode = null,
+    ) {}
+```
+
+Replace the existing `handleFailure` method with:
+
+```php
+    public function handleFailure(ValidationResult $result, Direction $direction = Direction::Request): void
+    {
+        $mode = $direction === Direction::Response
+            ? ($this->responseFailureMode ?? $this->failureMode)
+            : $this->failureMode;
+
+        match ($mode) {
+            FailureMode::Exception => throw new ContractViolationException($result, direction: $direction),
+            FailureMode::Log       => $this->logger->warning('API contract violation', [
+                'version'   => $result->version,
+                'errors'    => $result->errors,
+                'direction' => $direction->value,
+            ]),
+            FailureMode::Callable  => ($this->failureCallable)($result),
+        };
+    }
+```
+
+`Direction` is in the same `Fissible\Accord` namespace, so no `use` statement is required.
+
+- [ ] **Step 4: Run the full suite to verify pass + no regressions**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS. Test count is the prior 60 + 4 new from this task + the new Unit tests from Tasks 1/3/4 already committed. No new deprecations (still 5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ContractValidator.php tests/Feature/ContractValidatorTest.php
+git commit -m "feat: direction-aware handleFailure with response failure mode + direction log context (#5)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `AccordMiddleware` (PSR-15) passes direction
+
+**Files:**
+- Modify: `src/AccordMiddleware.php`
+- Create: `tests/Feature/AccordMiddlewareTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Feature;
+
+use Fissible\Accord\AccordMiddleware;
+use Fissible\Accord\ContractValidator;
+use Fissible\Accord\Exception\ContractViolationException;
+use Fissible\Accord\FailureMode;
+use Fissible\Accord\FileSpecSource;
+use Fissible\Accord\Tests\Support\RecordingLogger;
+use Fissible\Accord\VersionExtractor;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class AccordMiddlewareTest extends TestCase
+{
+    private function makeMiddleware(
+        FailureMode $request,
+        FailureMode $response,
+        RecordingLogger $logger,
+    ): AccordMiddleware {
+        $validator = new ContractValidator(
+            versionExtractor:    new VersionExtractor(),
+            specSource:          new FileSpecSource(dirname(__DIR__) . '/Fixtures', '{base}/{version}'),
+            failureMode:         $request,
+            failureCallable:     null,
+            logger:              $logger,
+            responseFailureMode: $response,
+        );
+
+        return new AccordMiddleware($validator);
+    }
+
+    private function handlerReturning(ResponseInterface $response): RequestHandlerInterface
+    {
+        return new class ($response) implements RequestHandlerInterface {
+            public function __construct(private ResponseInterface $response) {}
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+    }
+
+    public function test_request_violation_uses_request_mode(): void
+    {
+        // request=Exception → a missing required query param throws before the handler runs.
+        $middleware = $this->makeMiddleware(FailureMode::Exception, FailureMode::Log, new RecordingLogger());
+        $request    = new ServerRequest('GET', '/v1/roster'); // missing required page + X-Client
+
+        $this->expectException(ContractViolationException::class);
+        $middleware->process($request, $this->handlerReturning(new Response(200)));
+    }
+
+    public function test_response_violation_uses_response_mode(): void
+    {
+        // request=Log so the (also-invalid) request only logs; response=Exception throws on the bad body.
+        $logger     = new RecordingLogger();
+        $middleware = $this->makeMiddleware(FailureMode::Log, FailureMode::Exception, $logger);
+        $request    = (new ServerRequest('GET', '/v1/roster'))
+            ->withQueryParams(['page' => '1'])
+            ->withHeader('X-Client', 'abc');
+
+        $badResponse = (new Response(200))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(\Nyholm\Psr7\Stream::create('{"not":"an-array"}')); // schema expects array
+
+        try {
+            $middleware->process($request, $this->handlerReturning($badResponse));
+            $this->fail('Expected ContractViolationException for the response violation');
+        } catch (ContractViolationException $e) {
+            $this->assertSame('response', $e->direction->value);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter AccordMiddlewareTest`
+Expected: FAIL on `test_response_violation_uses_response_mode` — today `handleFailure` is called without a direction, so the response violation is handled with the request mode (`Log`) and never throws, so the `fail()` line fires. (`test_request_violation_uses_request_mode` may already pass since request defaults to Request direction.)
+
+- [ ] **Step 3: Pass direction in `process`**
+
+Replace the body of `process` in `src/AccordMiddleware.php`:
+
+```php
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $requestResult = $this->validator->validateRequest($request);
+
+        if (!$requestResult->valid) {
+            $this->validator->handleFailure($requestResult, Direction::Request);
+        }
+
+        $response = $handler->handle($request);
+
+        $responseResult = $this->validator->validateResponse($response, $request);
+
+        if (!$responseResult->valid) {
+            $this->validator->handleFailure($responseResult, Direction::Response);
+        }
+
+        return $response;
+    }
+```
+
+Add `use Fissible\Accord\Direction;`? No — `AccordMiddleware` is in namespace `Fissible\Accord`, same as `Direction`, so no import is needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit --filter AccordMiddlewareTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/AccordMiddleware.php tests/Feature/AccordMiddlewareTest.php
+git commit -m "feat: PSR-15 middleware routes request/response violations per direction (#5)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Laravel config — `request_violation_status` + array `failure_mode` docs
+
+**Files:**
+- Modify: `src/Drivers/Laravel/config/accord.php`
+
+No isolated test (config file is data). It is exercised by the provider tests in Task 9.
+
+- [ ] **Step 1: Update the `failure_mode` comment block**
+
+In `src/Drivers/Laravel/config/accord.php`, replace the `Failure Mode` comment block (the lines from `| Failure Mode` through the `*/`) so it documents the array form. Replace:
+
+```php
+    | How contract violations are reported. Options: exception | log | callable
+    |
+    */
+    'failure_mode' => env('ACCORD_FAILURE_MODE', 'exception'),
+```
+
+with:
+
+```php
+    | How contract violations are reported. Options: exception | log | callable
+    |
+    | May be a single value (applied to both directions) or an array with
+    | separate 'request' and 'response' modes, e.g.:
+    |   'failure_mode' => ['request' => 'exception', 'response' => 'log'],
+    | A missing array key falls back (response → request, request → exception).
+    |
+    */
+    'failure_mode' => env('ACCORD_FAILURE_MODE', 'exception'),
+```
+
+- [ ] **Step 2: Add the `request_violation_status` block**
+
+Immediately after the `'failure_mode' => ...,` line, add:
+
+```php
+
+    /*
+    |--------------------------------------------------------------------------
+    | Request Violation Status
+    |--------------------------------------------------------------------------
+    | HTTP status returned (in the Laravel driver) when a REQUEST violates the
+    | contract under exception mode. Must be a 4xx; anything else falls back to
+    | 422. Response violations are never rendered as a client error.
+    |
+    */
+    'request_violation_status' => (int) env('ACCORD_REQUEST_VIOLATION_STATUS', 422),
+```
+
+- [ ] **Step 3: Verify the suite still passes (config parse sanity)**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS (no new failures; this change is additive data).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Drivers/Laravel/config/accord.php
+git commit -m "feat: Laravel config for array failure_mode + request_violation_status (#5, #6)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `ValidateApiContract` — direction-aware + HTTP rendering
+
+**Files:**
+- Modify: `composer.json` (add `illuminate/http` to `require-dev`)
+- Modify: `src/Drivers/Laravel/Http/Middleware/ValidateApiContract.php`
+- Create: `tests/Feature/LaravelMiddlewareTest.php`
+
+- [ ] **Step 1: Add illuminate/http as a dev dependency**
+
+Run:
+
+```bash
+composer require --dev --no-interaction "illuminate/http:^10.0|^11.0|^12.0"
+```
+
+Expected: composer resolves and installs `illuminate/http` (+ its transitive deps) and updates `composer.json`/`composer.lock`. If composer picks a version requiring a newer PHP than 8.4, constrain to `^11.0`.
+
+- [ ] **Step 2: Write the failing tests**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Feature;
+
+use Fissible\Accord\ContractValidator;
+use Fissible\Accord\Direction;
+use Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract;
+use Fissible\Accord\Exception\ContractViolationException;
+use Fissible\Accord\FailureMode;
+use Fissible\Accord\FileSpecSource;
+use Fissible\Accord\Tests\Support\RecordingLogger;
+use Fissible\Accord\VersionExtractor;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+class LaravelMiddlewareTest extends TestCase
+{
+    private function makeValidator(
+        FailureMode $request,
+        FailureMode $response,
+        ?RecordingLogger $logger = null,
+    ): ContractValidator {
+        return new ContractValidator(
+            versionExtractor:    new VersionExtractor(),
+            specSource:          new FileSpecSource(dirname(__DIR__) . '/Fixtures', '{base}/{version}'),
+            failureMode:         $request,
+            failureCallable:     null,
+            logger:              $logger ?? new RecordingLogger(),
+            responseFailureMode: $response,
+        );
+    }
+
+    public function test_request_violation_renders_422_json(): void
+    {
+        $middleware = new ValidateApiContract($this->makeValidator(FailureMode::Exception, FailureMode::Log), 422);
+        $request    = Request::create('/v1/roster', 'GET'); // missing required page + X-Client
+
+        $response = $middleware->handle($request, fn () => new JsonResponse([], 200));
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(422, $response->getStatusCode());
+
+        $data = $response->getData(true);
+        $this->assertSame('Request does not satisfy the API contract', $data['message']);
+        $this->assertNotEmpty($data['errors']);
+    }
+
+    public function test_request_violation_status_is_configurable(): void
+    {
+        $middleware = new ValidateApiContract($this->makeValidator(FailureMode::Exception, FailureMode::Log), 418);
+        $request    = Request::create('/v1/roster', 'GET');
+
+        $response = $middleware->handle($request, fn () => new JsonResponse([], 200));
+
+        $this->assertSame(418, $response->getStatusCode());
+    }
+
+    public function test_response_violation_in_log_mode_passes_through(): void
+    {
+        $logger     = new RecordingLogger();
+        $middleware = new ValidateApiContract($this->makeValidator(FailureMode::Exception, FailureMode::Log, $logger), 422);
+
+        $request = Request::create('/v1/roster?page=1', 'GET');
+        $request->headers->set('X-Client', 'abc');
+
+        $original = new JsonResponse(['not' => 'an-array'], 200); // 200 schema expects an array
+        $response = $middleware->handle($request, fn () => $original);
+
+        $this->assertSame($original, $response);            // untouched
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('response', $logger->records[0]['context']['direction']);
+    }
+
+    public function test_response_violation_in_exception_mode_propagates_as_server_error(): void
+    {
+        $middleware = new ValidateApiContract($this->makeValidator(FailureMode::Exception, FailureMode::Exception), 422);
+
+        $request = Request::create('/v1/roster?page=1', 'GET');
+        $request->headers->set('X-Client', 'abc');
+
+        try {
+            $middleware->handle($request, fn () => new JsonResponse(['not' => 'an-array'], 200));
+            $this->fail('Expected the response violation to propagate, not render as a client error');
+        } catch (ContractViolationException $e) {
+            $this->assertSame(Direction::Response, $e->direction);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter LaravelMiddlewareTest`
+Expected: FAIL — `ValidateApiContract::__construct()` does not yet accept a second argument, and request violations currently throw (rendered as no JSON).
+
+- [ ] **Step 4: Implement direction-aware handling + rendering**
+
+Replace the entire contents of `src/Drivers/Laravel/Http/Middleware/ValidateApiContract.php` with:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Drivers\Laravel\Http\Middleware;
+
+use Closure;
+use Fissible\Accord\ContractValidator;
+use Fissible\Accord\Direction;
+use Fissible\Accord\Exception\ContractViolationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+
+class ValidateApiContract
+{
+    private readonly PsrHttpFactory $bridge;
+
+    public function __construct(
+        private readonly ContractValidator $validator,
+        private readonly int $requestViolationStatus = 422,
+    ) {
+        $factory      = new Psr17Factory();
+        $this->bridge = new PsrHttpFactory($factory, $factory, $factory, $factory);
+    }
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $psrRequest    = $this->bridge->createRequest($request);
+        $requestResult = $this->validator->validateRequest($psrRequest);
+
+        if (!$requestResult->valid) {
+            try {
+                $this->validator->handleFailure($requestResult, Direction::Request);
+            } catch (ContractViolationException $e) {
+                return new JsonResponse([
+                    'message' => 'Request does not satisfy the API contract',
+                    'errors'  => $e->result->errors,
+                ], $this->requestViolationStatus);
+            }
+        }
+
+        $response = $next($request);
+
+        $psrResponse    = $this->bridge->createResponse($response);
+        $responseResult = $this->validator->validateResponse($psrResponse, $psrRequest);
+
+        if (!$responseResult->valid) {
+            // Response violations are a server-side problem. Under exception mode this
+            // propagates (Laravel renders a 500); under log mode it is logged and the
+            // original response passes through untouched. Never rendered as a 4xx.
+            $this->validator->handleFailure($responseResult, Direction::Response);
+        }
+
+        return $response;
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit --filter LaravelMiddlewareTest`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add composer.json composer.lock src/Drivers/Laravel/Http/Middleware/ValidateApiContract.php tests/Feature/LaravelMiddlewareTest.php
+git commit -m "feat: render request violations as JSON 4xx; response violations stay server errors (#6)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: `AccordServiceProvider` — wire resolvePair + bind middleware with status
+
+**Files:**
+- Modify: `src/Drivers/Laravel/Providers/AccordServiceProvider.php`
+- Test: `tests/Feature/LaravelServiceProviderTest.php` (append tests; reuse the file's existing `FakeLaravelContainer`, `LaravelConfig`, `RecordingLogger`, `FakeLogManager`, and the global `config`/`base_path` stubs)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these imports to the `Fissible\Accord\Tests\Feature` namespace `use` block at the top of `tests/Feature/LaravelServiceProviderTest.php`:
+
+```php
+use Fissible\Accord\Direction;
+use Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract;
+use Fissible\Accord\Exception\ContractViolationException;
+use Fissible\Accord\ValidationResult;
+use ReflectionProperty;
+```
+
+(Note: `ContractValidator`, `AccordServiceProvider`, `LoggerInterface` are already imported in this file. `ValidationResult` may already be imported — if so, skip the duplicate.)
+
+Add these methods inside `class LaravelServiceProviderTest`:
+
+```php
+    public function test_array_failure_mode_logs_response_violations(): void
+    {
+        LaravelConfig::$values['accord.failure_mode'] = ['request' => 'exception', 'response' => 'log'];
+
+        $logger = new RecordingLogger();
+        $app    = new FakeLaravelContainer([LoggerInterface::class => $logger]);
+
+        (new AccordServiceProvider($app))->register();
+
+        $validator = $app->make(ContractValidator::class);
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
+
+        $this->assertCount(1, $logger->records);
+    }
+
+    public function test_array_failure_mode_throws_on_request_violations(): void
+    {
+        LaravelConfig::$values['accord.failure_mode'] = ['request' => 'exception', 'response' => 'log'];
+
+        $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+        (new AccordServiceProvider($app))->register();
+
+        $validator = $app->make(ContractValidator::class);
+
+        $this->expectException(ContractViolationException::class);
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Request);
+    }
+
+    public function test_provider_binds_middleware_with_configured_status(): void
+    {
+        LaravelConfig::$values['accord.request_violation_status'] = 418;
+
+        $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+        (new AccordServiceProvider($app))->register();
+
+        $middleware = $app->make(ValidateApiContract::class);
+
+        $this->assertSame(418, $this->readStatus($middleware));
+    }
+
+    public function test_provider_casts_string_status_and_guards_non_4xx(): void
+    {
+        $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+
+        LaravelConfig::$values['accord.request_violation_status'] = '418';
+        (new AccordServiceProvider($app))->register();
+        $this->assertSame(418, $this->readStatus($app->make(ValidateApiContract::class)));
+
+        // Out-of-4xx falls back to 422. Fresh container so the singleton is rebuilt.
+        $app2 = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+        LaravelConfig::$values['accord.request_violation_status'] = 500;
+        (new AccordServiceProvider($app2))->register();
+        $this->assertSame(422, $this->readStatus($app2->make(ValidateApiContract::class)));
+    }
+
+    private function readStatus(ValidateApiContract $middleware): int
+    {
+        $property = new ReflectionProperty(ValidateApiContract::class, 'requestViolationStatus');
+
+        return $property->getValue($middleware);
+    }
+```
+
+Also add `'accord.request_violation_status' => 422,` to the `LaravelConfig::$values` array in this file's `setUp()` so the base config has the key (next to the existing `'accord.log_channel' => null,` line).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter LaravelServiceProviderTest`
+Expected: FAIL — `Nothing bound for Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract` (provider does not bind it yet), and array config would currently hit `FailureMode::from(array)`.
+
+- [ ] **Step 3: Update the provider**
+
+In `src/Drivers/Laravel/Providers/AccordServiceProvider.php`, add these imports near the existing `use` statements:
+
+```php
+use Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract;
+```
+
+Replace the `ContractValidator` singleton registration (the `$this->app->singleton(ContractValidator::class, ...)` closure) with:
+
+```php
+        $this->app->singleton(ContractValidator::class, function () {
+            [$requestMode, $responseMode] = FailureMode::resolvePair(config('accord.failure_mode'));
+            $failureCallable = config('accord.failure_callable');
+
+            if (is_array($failureCallable) || is_string($failureCallable)) {
+                $failureCallable = $this->app->make(...(array) $failureCallable);
+            }
+
+            return new ContractValidator(
+                versionExtractor:    $this->app->make(VersionExtractor::class),
+                specSource:          $this->app->make(SpecSourceInterface::class),
+                failureMode:         $requestMode,
+                failureCallable:     $failureCallable,
+                logger:              $this->resolveLogger(),
+                responseFailureMode: $responseMode,
+            );
+        });
+```
+
+Immediately after the `AccordMiddleware` singleton registration (the existing `$this->app->singleton(AccordMiddleware::class, ...)` block), add a binding for the Laravel middleware:
+
+```php
+        $this->app->singleton(ValidateApiContract::class, fn () => new ValidateApiContract(
+            $this->app->make(ContractValidator::class),
+            $this->resolveRequestViolationStatus(),
+        ));
+```
+
+Add this private helper to the class (next to the existing `resolveLogger`):
+
+```php
+    private function resolveRequestViolationStatus(): int
+    {
+        $status = (int) config('accord.request_violation_status', 422);
+
+        return ($status >= 400 && $status <= 499) ? $status : 422;
+    }
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS, including the existing `test_laravel_provider_injects_default_logger` and `test_laravel_provider_uses_configured_log_channel` (unchanged behavior). No new deprecations.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Drivers/Laravel/Providers/AccordServiceProvider.php tests/Feature/LaravelServiceProviderTest.php
+git commit -m "feat: provider resolves per-direction modes and binds middleware with guarded status (#5, #6)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: `AccordFactory` — parse failure mode via resolvePair
+
+**Files:**
+- Modify: `src/AccordFactory.php`
+- Test: `tests/Unit/AccordFactoryTest.php` (append tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these methods to `tests/Unit/AccordFactoryTest.php` (use the existing imports; add `use Fissible\Accord\AccordMiddleware;` if not already present):
+
+```php
+    public function test_make_accepts_array_failure_mode_without_error(): void
+    {
+        $middleware = AccordFactory::make(
+            ['failure_mode' => ['request' => 'exception', 'response' => 'log']],
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        $this->assertInstanceOf(AccordMiddleware::class, $middleware);
+    }
+
+    public function test_make_still_accepts_scalar_failure_mode(): void
+    {
+        $middleware = AccordFactory::make(
+            ['failure_mode' => 'log'],
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        $this->assertInstanceOf(AccordMiddleware::class, $middleware);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter AccordFactoryTest`
+Expected: FAIL on `test_make_accepts_array_failure_mode_without_error` — `FailureMode::from()` receives an array → `TypeError`.
+
+- [ ] **Step 3: Use resolvePair in the factory**
+
+In `src/AccordFactory.php`, replace:
+
+```php
+        $failureMode     = FailureMode::from($config['failure_mode'] ?? 'exception');
+        $failureCallable = $config['failure_callable'] ?? null;
+
+        $validator = new ContractValidator(
+            versionExtractor: $versionExtractor,
+            specSource:       $specSource,
+            failureMode:      $failureMode,
+            failureCallable:  $failureCallable,
+        );
+```
+
+with:
+
+```php
+        [$requestMode, $responseMode] = FailureMode::resolvePair($config['failure_mode'] ?? 'exception');
+        $failureCallable = $config['failure_callable'] ?? null;
+
+        $validator = new ContractValidator(
+            versionExtractor:    $versionExtractor,
+            specSource:          $specSource,
+            failureMode:         $requestMode,
+            failureCallable:     $failureCallable,
+            responseFailureMode: $responseMode,
+        );
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit --filter AccordFactoryTest`
+Expected: PASS (existing AccordFactory tests + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/AccordFactory.php tests/Unit/AccordFactoryTest.php
+git commit -m "feat: AccordFactory parses string|array failure_mode via resolvePair (#5)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: README documentation
+
+**Files:**
+- Modify: `README.md`
+
+No test (docs). Document the array config form, `request_violation_status`, and the rendering behavior.
+
+- [ ] **Step 1: Update the config snippet**
+
+In `README.md`, find the published-config snippet (the array beginning `'failure_mode' => env('ACCORD_FAILURE_MODE', 'exception'),`). Add a `request_violation_status` line and a note about the array form. After the `'log_channel' => env('ACCORD_LOG_CHANNEL'),` line (added in the prior PR), add:
+
+```php
+    'request_violation_status' => env('ACCORD_REQUEST_VIOLATION_STATUS', 422), // request 4xx; non-4xx → 422
+```
+
+Below that snippet, add a short prose paragraph:
+
+```markdown
+**Per-direction failure modes.** `failure_mode` may be a single value applied to both
+directions, or an array with separate `request` and `response` modes:
+
+```php
+'failure_mode' => ['request' => 'exception', 'response' => 'log'],
+```
+
+In the Laravel driver, a **request** violation under `exception` mode is rendered as a JSON
+response (`{ "message": ..., "errors": [...] }`) with `request_violation_status` (default
+`422`; a non-4xx value falls back to `422`). A **response** violation is treated as a
+server-side problem: under `exception` mode it surfaces as a 500, and under `log` mode it is
+logged while the original response passes through unchanged — it is never rendered as a 4xx.
+```
+
+- [ ] **Step 2: Verify the suite is unaffected**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS (docs-only change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document per-direction failure modes and request violation rendering (#5, #6)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Final verification
+
+- [ ] **Step 1: Full suite, clean tree**
+
+Run:
+
+```bash
+vendor/bin/phpunit --colors=never
+git diff --check
+```
+
+Expected: All tests pass (baseline 60 + the new tests from Tasks 1, 3, 4, 5, 6, 8, 9, 10). Deprecations remain **5** (no new ones). `git diff --check` prints nothing.
+
+- [ ] **Step 2: Confirm the core stayed framework-agnostic**
+
+Run:
+
+```bash
+grep -rn "Illuminate\\\\" src --include=*.php | grep -v "src/Drivers/"
+```
+
+Expected: **no output** — no `Illuminate\` reference leaked outside `src/Drivers/`.
+
+- [ ] **Step 3: Push and open the PR (only if the user asks)**
+
+Do not push or open a PR unless the user requests it. When asked:
+
+```bash
+git push -u origin feat/per-direction-failure-modes
+gh pr create --title "feat: per-direction failure modes + HTTP-aware rendering (#5, #6)" --body "$(cat <<'EOF'
+Implements #5 (per-direction failure modes) and #6 (HTTP-aware rendering).
+
+- `Direction` enum + `FailureMode::resolvePair` (string|array config, shared by factory & provider)
+- Direction-aware `ContractValidator::handleFailure` with response failure mode + direction in log context
+- `ContractViolationException` carries `direction` (trailing param — ABI preserved)
+- Laravel: request violations render as JSON 4xx (configurable, default 422, non-4xx → 422); response violations stay server errors
+- Provider binds `ValidateApiContract` so the configured status actually applies
+- `illuminate/http` added to require-dev for middleware integration tests
+
+Fully backward compatible: scalar `failure_mode` behaves exactly as before.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** Direction enum (T1), resolvePair string/array/fallback/throw (T3), exception direction + ABI (T4), validator per-direction + log context + backward-compat (T5), PSR-15 directions (T6), config status + array docs (T7), middleware rendering + response-stays-server-error (T8), provider binding + cast + 4xx guard (T9), factory array support (T10), README (T11), framework-agnostic guard (T12). All spec sections map to a task.
+- **Type consistency:** `responseFailureMode` (named arg) used identically in T5/T9/T10; `requestViolationStatus` private prop name matches the reflection read in T9; `Direction::Request|Response` and `->value` used consistently.
+- **No placeholders:** every code step shows full code; every run step states the expected result.

--- a/docs/superpowers/specs/2026-06-14-per-direction-failure-modes-and-rendering-design.md
+++ b/docs/superpowers/specs/2026-06-14-per-direction-failure-modes-and-rendering-design.md
@@ -1,0 +1,193 @@
+# Per-direction failure modes (#5) + HTTP-aware rendering (#6)
+
+**Date:** 2026-06-14
+**Issues:** #5 (per-direction failure modes), #6 (HTTP-aware rendering)
+**Package state:** accord is released at v1.0.0 — backward compatibility is a hard constraint.
+
+## Problem
+
+1. `ContractValidator::handleFailure(ValidationResult)` applies a single `FailureMode`
+   regardless of whether the request or the response violated the contract. A common
+   production posture — reject bad requests, only log bad responses — is impossible.
+2. `ContractViolationException` is a plain `RuntimeException` with no HTTP awareness, so
+   in Laravel a request violation surfaces as a 500. Clients should see a 4xx for their
+   own bad request; a bad *response* is a server bug and must not masquerade as a 4xx.
+
+## Decisions (confirmed with user)
+
+- **Config shape:** `failure_mode` accepts a **string OR an array**
+  `['request' => ..., 'response' => ...]`. Scalar continues to apply to both directions.
+- **Request-violation status:** **configurable, default 422** via
+  `request_violation_status` (env `ACCORD_REQUEST_VIOLATION_STATUS`).
+- **Response-direction violations:** **never rendered as a client error.** Under
+  exception mode a response violation propagates (Laravel 500); under log mode it is
+  logged and the original response passes through.
+- **Response body shape:** flat `{ "message": string, "errors": string[] }` (accord's
+  native error shape), aligned with Laravel's 422 `message`/`errors` convention.
+- **Status stays out of the core exception:** the core exception carries only
+  `direction`; the Laravel driver maps direction → status. Core stays framework-agnostic.
+
+## Architecture
+
+The core (`src/` excluding `src/Drivers/`) must not depend on any framework. Rendering
+is therefore Laravel-driver-only; the core exposes direction so any driver can render.
+
+### Components (dependency order, leaves → roots)
+
+1. **`Direction` enum** (core, new) — a **string-backed** enum (the spec relies on
+   `$direction->value` for log context and tests assert `'response'`):
+   ```php
+   enum Direction: string
+   {
+       case Request  = 'request';
+       case Response = 'response';
+   }
+   ```
+   Leaf; everything hangs off it.
+
+2. **`FailureMode::resolvePair(string|array): array{0: FailureMode, 1: FailureMode}`**
+   (core) — single source of truth for the union shape. Used by both `AccordFactory`
+   and the Laravel provider so parsing never diverges.
+   - `'exception'` → `[Exception, Exception]`
+   - `['request'=>'exception','response'=>'log']` → `[Exception, Log]`
+   - `['request'=>'exception']` → `[Exception, Exception]` (response key **missing** → falls back to request)
+   - `['response'=>'log']` → `[Exception, Log]` (request key **missing** → falls back to the
+     default `Exception`; response uses its explicit value)
+   - **Fallback vs invalid is distinct:** a *missing* array key falls back. A key that is
+     *present but holds an unknown string* still throws `ValueError` via `FailureMode::from`
+     — we never silently swallow a typo'd mode. A scalar that is an unknown string likewise
+     throws.
+   - **Empty/absent precisely:** `null`/unset config and `[]` (empty array — both keys
+     missing) fall back to `Exception`. An **explicit empty scalar string `''`** (e.g.
+     `ACCORD_FAILURE_MODE=` set-but-blank, which Laravel's `env()` returns as `''` rather
+     than the default) is treated as any other invalid mode and **throws** `ValueError`. We
+     do not silently tolerate blank env values — a blank mode is a misconfiguration, not a
+     request to use the default.
+
+3. **`ContractViolationException`** (core) — add `public readonly Direction $direction`
+   (default `Request`). No HTTP status. **Preserve the full existing constructor ABI:**
+   the current signature is
+   `(ValidationResult $result, string $message = '', int $code = 0, ?Throwable $previous = null)`.
+   `Direction` is added as a **trailing** parameter
+   (`..., ?Throwable $previous = null, Direction $direction = Direction::Request`), so an
+   existing positional call like `new ContractViolationException($result, 'msg', 0, $prev)`
+   keeps working unchanged. The validator constructs with the named arg `direction: $direction`.
+
+4. **`ContractValidator`** (core):
+   - Constructor gains one optional trailing param `?FailureMode $responseFailureMode = null`.
+     `failureMode` remains the request mode and the fallback.
+   - `handleFailure(ValidationResult $result, Direction $direction = Direction::Request)`.
+     Response mode = `responseFailureMode ?? failureMode`. Throws
+     `new ContractViolationException($result, direction: $direction)` in exception mode
+     (named arg, since `direction` is now the trailing constructor parameter).
+   - **Log context includes direction:** the `Log` branch adds
+     `'direction' => $direction->value` to the existing `version`/`errors` context. Under a
+     scalar `log` config both directions log, so this is the only way to tell them apart.
+     Non-breaking — purely additive context.
+   - **Backward compatibility:** with a scalar config, response mode == request mode, so
+     behavior is identical to today.
+
+5. **`AccordMiddleware`** (core, PSR-15) — pass `Direction::Request` /
+   `Direction::Response` to `handleFailure`. No rendering (Slim/Mezzio have their own
+   error handlers, which may read `$e->direction`).
+
+6. **Laravel config `accord.php`** — document `failure_mode` as string-or-array; default
+   stays scalar `env('ACCORD_FAILURE_MODE','exception')`. Add
+   `request_violation_status => (int) env('ACCORD_REQUEST_VIOLATION_STATUS', 422)`.
+   **Cast at the config boundary:** `env()` yields strings and the codebase runs under
+   `strict_types=1`, so the value is cast to `int` here (and again defensively in the
+   provider). **Range policy:** the provider validates the resolved status is a 4xx
+   (`>= 400 && <= 499`); anything outside that range falls back to `422`. Rationale: a
+   request-violation response must be a client error — a typo'd `200`/`500` must not be
+   able to mislabel a bad request as success or a server fault.
+
+7. **`AccordServiceProvider`** — resolve modes via `FailureMode::resolvePair(config('accord.failure_mode'))`,
+   pass both to `ContractValidator`. Resolve the status with `(int) config('accord.request_violation_status', 422)`,
+   apply the 4xx range guard (else `422`), and **explicitly bind `ValidateApiContract`**
+   in the container with that status — e.g.
+   `$this->app->singleton(ValidateApiContract::class, fn () => new ValidateApiContract($validator, $status))`.
+   Without an explicit binding, Laravel autowires the middleware for route resolution and,
+   because `requestViolationStatus` is a primitive with a default, silently uses `422` and
+   ignores config. The binding is what makes the config override actually take effect.
+
+8. **`ValidateApiContract`** (Laravel middleware):
+   ```
+   request invalid  → handleFailure(result, Request)
+                        catch ContractViolationException → JsonResponse({message, errors}, status)
+   response invalid → handleFailure(result, Response)
+                        exception mode → propagates → Laravel 500 (not caught)
+                        log mode       → logged, original response returned unchanged
+   ```
+   Constructor gains `int $requestViolationStatus = 422`; the value is supplied by the
+   provider's explicit container binding (component 7), not by autowiring.
+
+9. **`AccordFactory`** — replace `FailureMode::from($config['failure_mode'])` (line 33,
+   breaks on array) with `FailureMode::resolvePair(...)`; pass both modes through.
+
+10. **README** — document the array config form, `request_violation_status`, and the
+    request-vs-response rendering behavior.
+
+## Data flow (Laravel, prod posture: request=exception, response=log)
+
+```
+HTTP request
+  → ValidateApiContract::handle
+    → validateRequest → invalid → handleFailure(Request) → throws → caught → 422 JSON  (short-circuit)
+    → valid → $next($request) → controller → response
+      → validateResponse → invalid → handleFailure(Response) → log mode → warning logged
+      → original response returned to client unchanged
+```
+
+## Error handling
+
+- Request violation, exception mode: `ContractViolationException(direction=Request)` caught
+  in the Laravel middleware → JSON at `request_violation_status`.
+- Response violation, exception mode: `ContractViolationException(direction=Response)` NOT
+  caught → Laravel renders 500. Correct: a contract-violating response must not be sent.
+- Callable mode: unchanged; `failureCallable` invoked for either direction (the callable
+  may inspect `result` but not direction in this iteration — YAGNI until needed).
+- Fail-open semantics elsewhere (missing spec, unmatched path, etc.) are unchanged.
+
+## Testing (TDD, one behavior per test)
+
+Core (`tests/Feature` / `tests/Unit`):
+- `resolvePair`: scalar → both; full array; `['request'=>...]` (response key missing → falls
+  back to request); `['response'=>...]` (request key missing → falls back to default Exception);
+  array with a present-but-unknown mode string → throws `ValueError`; scalar unknown → throws.
+- `handleFailure(Request)` uses request mode; `handleFailure(Response)` uses response mode
+  (e.g. request=exception throws, response=log logs — assert via RecordingLogger).
+- Log context carries `direction` (assert `'direction' => 'response'` in the logged context).
+- Scalar config: response direction still uses the single mode (backward-compat lock).
+- `ContractViolationException`: carries the supplied `direction`; and the legacy positional
+  call `new ContractViolationException($result, 'msg', 0, $prev)` still constructs (ABI lock).
+
+Laravel driver:
+- Request violation under exception → 422 JSON with `message` + flat `errors[]`.
+- `request_violation_status` override respected — and a **string** env value (e.g. `"418"`)
+  is cast and applied; an out-of-4xx value (e.g. `"500"`/`"200"`) falls back to `422`.
+- Provider **binding** is what carries the status: resolving `ValidateApiContract` from the
+  container yields the configured status (guards against the autowire-ignores-config trap).
+- Response violation under exception → exception propagates (assert thrown).
+- Response violation under log → logged, original response returned, status unchanged.
+- Provider parses array config and scalar config into the right modes.
+
+All tests must keep the suite green (currently 60 tests) with no new deprecations.
+
+**Test dependency note (for the implementation plan):** the existing Tier-1 provider test
+(`LaravelServiceProviderTest`) avoids a real Illuminate dependency by defining local stubs
+(a `ServiceProvider` stub, `config()`/`base_path()` functions, a fake container, a
+`RecordingLogger`). The new `ValidateApiContract` rendering tests need a real
+`Illuminate\Http\Request` and assert on a real `JsonResponse` (status + JSON body) through
+the Symfony PSR bridge — stubbing those faithfully is more effort than it's worth and risks
+testing the stub instead of the behavior. **Recommended:** add `illuminate/http` (matching
+the framework support range) to `require-dev` and write these as real integration tests,
+consistent with the project rule to prefer real dependency chains over mocks. The provider
+mode-resolution tests can continue to use the lightweight container/config stubs. Final
+choice (dev dep vs stubs) is settled in the implementation plan.
+
+## Out of scope (YAGNI)
+
+- Per-direction *callables* (single callable still used for both).
+- Configurable response body shape / message text.
+- Rendering for Slim/Mezzio (drivers expose `direction`; their error handlers decide).
+- Header/cookie-based content negotiation for the error response (always JSON).

--- a/src/AccordFactory.php
+++ b/src/AccordFactory.php
@@ -30,14 +30,15 @@ final class AccordFactory
 
         $specSource = self::makeSpecSource($config, $basePath);
 
-        $failureMode     = FailureMode::from($config['failure_mode'] ?? 'exception');
+        [$requestMode, $responseMode] = FailureMode::resolvePair($config['failure_mode'] ?? 'exception');
         $failureCallable = $config['failure_callable'] ?? null;
 
         $validator = new ContractValidator(
-            versionExtractor: $versionExtractor,
-            specSource:       $specSource,
-            failureMode:      $failureMode,
-            failureCallable:  $failureCallable,
+            versionExtractor:    $versionExtractor,
+            specSource:          $specSource,
+            failureMode:         $requestMode,
+            failureCallable:     $failureCallable,
+            responseFailureMode: $responseMode,
         );
 
         return new AccordMiddleware($validator);

--- a/src/AccordMiddleware.php
+++ b/src/AccordMiddleware.php
@@ -24,7 +24,7 @@ class AccordMiddleware implements MiddlewareInterface
         $requestResult = $this->validator->validateRequest($request);
 
         if (!$requestResult->valid) {
-            $this->validator->handleFailure($requestResult);
+            $this->validator->handleFailure($requestResult, Direction::Request);
         }
 
         $response = $handler->handle($request);
@@ -32,7 +32,7 @@ class AccordMiddleware implements MiddlewareInterface
         $responseResult = $this->validator->validateResponse($response, $request);
 
         if (!$responseResult->valid) {
-            $this->validator->handleFailure($responseResult);
+            $this->validator->handleFailure($responseResult, Direction::Response);
         }
 
         return $response;

--- a/src/ContractValidator.php
+++ b/src/ContractValidator.php
@@ -28,6 +28,7 @@ class ContractValidator
         /** @var callable(ValidationResult): void|null */
         private readonly mixed $failureCallable = null,
         private readonly LoggerInterface $logger = new NullLogger(),
+        private readonly ?FailureMode $responseFailureMode = null,
     ) {}
 
     public function validateRequest(ServerRequestInterface $request): ValidationResult
@@ -128,13 +129,18 @@ class ContractValidator
             : ValidationResult::invalid($errors, $version);
     }
 
-    public function handleFailure(ValidationResult $result): void
+    public function handleFailure(ValidationResult $result, Direction $direction = Direction::Request): void
     {
-        match ($this->failureMode) {
-            FailureMode::Exception => throw new ContractViolationException($result),
+        $mode = $direction === Direction::Response
+            ? ($this->responseFailureMode ?? $this->failureMode)
+            : $this->failureMode;
+
+        match ($mode) {
+            FailureMode::Exception => throw new ContractViolationException($result, direction: $direction),
             FailureMode::Log       => $this->logger->warning('API contract violation', [
-                'version' => $result->version,
-                'errors'  => $result->errors,
+                'version'   => $result->version,
+                'errors'    => $result->errors,
+                'direction' => $direction->value,
             ]),
             FailureMode::Callable  => ($this->failureCallable)($result),
         };

--- a/src/Direction.php
+++ b/src/Direction.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord;
+
+enum Direction: string
+{
+    case Request  = 'request';
+    case Response = 'response';
+}

--- a/src/Drivers/Laravel/Http/Middleware/ValidateApiContract.php
+++ b/src/Drivers/Laravel/Http/Middleware/ValidateApiContract.php
@@ -6,6 +6,9 @@ namespace Fissible\Accord\Drivers\Laravel\Http\Middleware;
 
 use Closure;
 use Fissible\Accord\ContractValidator;
+use Fissible\Accord\Direction;
+use Fissible\Accord\Exception\ContractViolationException;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
@@ -16,6 +19,7 @@ class ValidateApiContract
 
     public function __construct(
         private readonly ContractValidator $validator,
+        private readonly int $requestViolationStatus = 422,
     ) {
         $factory      = new Psr17Factory();
         $this->bridge = new PsrHttpFactory($factory, $factory, $factory, $factory);
@@ -27,7 +31,14 @@ class ValidateApiContract
         $requestResult = $this->validator->validateRequest($psrRequest);
 
         if (!$requestResult->valid) {
-            $this->validator->handleFailure($requestResult);
+            try {
+                $this->validator->handleFailure($requestResult, Direction::Request);
+            } catch (ContractViolationException $e) {
+                return new JsonResponse([
+                    'message' => 'Request does not satisfy the API contract',
+                    'errors'  => $e->result->errors,
+                ], $this->requestViolationStatus);
+            }
         }
 
         $response = $next($request);
@@ -36,7 +47,10 @@ class ValidateApiContract
         $responseResult = $this->validator->validateResponse($psrResponse, $psrRequest);
 
         if (!$responseResult->valid) {
-            $this->validator->handleFailure($responseResult);
+            // Response violations are a server-side problem. Under exception mode this
+            // propagates (Laravel renders a 500); under log mode it is logged and the
+            // original response passes through untouched. Never rendered as a 4xx.
+            $this->validator->handleFailure($responseResult, Direction::Response);
         }
 
         return $response;

--- a/src/Drivers/Laravel/Providers/AccordServiceProvider.php
+++ b/src/Drivers/Laravel/Providers/AccordServiceProvider.php
@@ -6,6 +6,7 @@ namespace Fissible\Accord\Drivers\Laravel\Providers;
 
 use Fissible\Accord\AccordMiddleware;
 use Fissible\Accord\ContractValidator;
+use Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract;
 use Fissible\Accord\FailureMode;
 use Fissible\Accord\FileSpecSource;
 use Fissible\Accord\SpecSourceInterface;
@@ -42,7 +43,7 @@ class AccordServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(ContractValidator::class, function () {
-            $failureMode     = FailureMode::from(config('accord.failure_mode'));
+            [$requestMode, $responseMode] = FailureMode::resolvePair(config('accord.failure_mode'));
             $failureCallable = config('accord.failure_callable');
 
             if (is_array($failureCallable) || is_string($failureCallable)) {
@@ -50,16 +51,22 @@ class AccordServiceProvider extends ServiceProvider
             }
 
             return new ContractValidator(
-                versionExtractor: $this->app->make(VersionExtractor::class),
-                specSource:       $this->app->make(SpecSourceInterface::class),
-                failureMode:      $failureMode,
-                failureCallable:  $failureCallable,
-                logger:           $this->resolveLogger(),
+                versionExtractor:    $this->app->make(VersionExtractor::class),
+                specSource:          $this->app->make(SpecSourceInterface::class),
+                failureMode:         $requestMode,
+                failureCallable:     $failureCallable,
+                logger:              $this->resolveLogger(),
+                responseFailureMode: $responseMode,
             );
         });
 
         $this->app->singleton(AccordMiddleware::class, fn () => new AccordMiddleware(
             $this->app->make(ContractValidator::class),
+        ));
+
+        $this->app->singleton(ValidateApiContract::class, fn () => new ValidateApiContract(
+            $this->app->make(ContractValidator::class),
+            $this->resolveRequestViolationStatus(),
         ));
     }
 
@@ -68,6 +75,13 @@ class AccordServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../config/accord.php' => config_path('accord.php'),
         ], 'accord-config');
+    }
+
+    private function resolveRequestViolationStatus(): int
+    {
+        $status = (int) config('accord.request_violation_status', 422);
+
+        return ($status >= 400 && $status <= 499) ? $status : 422;
     }
 
     private function resolveLogger(): LoggerInterface

--- a/src/Drivers/Laravel/config/accord.php
+++ b/src/Drivers/Laravel/config/accord.php
@@ -7,8 +7,24 @@ return [
     |--------------------------------------------------------------------------
     | How contract violations are reported. Options: exception | log | callable
     |
+    | May be a single value (applied to both directions) or an array with
+    | separate 'request' and 'response' modes, e.g.:
+    |   'failure_mode' => ['request' => 'exception', 'response' => 'log'],
+    | A missing array key falls back (response → request, request → exception).
+    |
     */
     'failure_mode' => env('ACCORD_FAILURE_MODE', 'exception'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Request Violation Status
+    |--------------------------------------------------------------------------
+    | HTTP status returned (in the Laravel driver) when a REQUEST violates the
+    | contract under exception mode. Must be a 4xx; anything else falls back to
+    | 422. Response violations are never rendered as a client error.
+    |
+    */
+    'request_violation_status' => (int) env('ACCORD_REQUEST_VIOLATION_STATUS', 422),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Exception/ContractViolationException.php
+++ b/src/Exception/ContractViolationException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fissible\Accord\Exception;
 
+use Fissible\Accord\Direction;
 use Fissible\Accord\ValidationResult;
 use RuntimeException;
 
@@ -14,6 +15,7 @@ class ContractViolationException extends RuntimeException
         string $message = '',
         int $code = 0,
         ?\Throwable $previous = null,
+        public readonly Direction $direction = Direction::Request,
     ) {
         parent::__construct(
             $message ?: sprintf(

--- a/src/FailureMode.php
+++ b/src/FailureMode.php
@@ -9,4 +9,35 @@ enum FailureMode: string
     case Exception = 'exception';
     case Log       = 'log';
     case Callable  = 'callable';
+
+    /**
+     * Resolve a string|array failure-mode config into [request, response] modes.
+     *
+     * - A scalar string applies to both directions.
+     * - An array may set 'request' and/or 'response'; a MISSING key falls back
+     *   (response → request, request → Exception default).
+     * - null / [] fall back to Exception for both.
+     * - A present-but-unknown string (scalar or array value) throws ValueError
+     *   via self::from — typos are never silently swallowed.
+     *
+     * @param string|array<string, string>|null $config
+     * @return array{0: FailureMode, 1: FailureMode}
+     */
+    public static function resolvePair(string|array|null $config): array
+    {
+        if ($config === null) {
+            return [self::Exception, self::Exception];
+        }
+
+        if (is_array($config)) {
+            $request  = isset($config['request'])  ? self::from($config['request'])  : self::Exception;
+            $response = isset($config['response']) ? self::from($config['response']) : $request;
+
+            return [$request, $response];
+        }
+
+        $mode = self::from($config);
+
+        return [$mode, $mode];
+    }
 }

--- a/tests/Feature/AccordMiddlewareTest.php
+++ b/tests/Feature/AccordMiddlewareTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Feature;
+
+use Fissible\Accord\AccordMiddleware;
+use Fissible\Accord\ContractValidator;
+use Fissible\Accord\Exception\ContractViolationException;
+use Fissible\Accord\FailureMode;
+use Fissible\Accord\FileSpecSource;
+use Fissible\Accord\Tests\Support\RecordingLogger;
+use Fissible\Accord\VersionExtractor;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class AccordMiddlewareTest extends TestCase
+{
+    private function makeMiddleware(
+        FailureMode $request,
+        FailureMode $response,
+        RecordingLogger $logger,
+    ): AccordMiddleware {
+        $validator = new ContractValidator(
+            versionExtractor:    new VersionExtractor(),
+            specSource:          new FileSpecSource(dirname(__DIR__) . '/Fixtures', '{base}/{version}'),
+            failureMode:         $request,
+            failureCallable:     null,
+            logger:              $logger,
+            responseFailureMode: $response,
+        );
+
+        return new AccordMiddleware($validator);
+    }
+
+    private function handlerReturning(ResponseInterface $response): RequestHandlerInterface
+    {
+        return new class ($response) implements RequestHandlerInterface {
+            public function __construct(private ResponseInterface $response) {}
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+    }
+
+    public function test_request_violation_uses_request_mode(): void
+    {
+        // request=Exception → a missing required query param throws before the handler runs.
+        $middleware = $this->makeMiddleware(FailureMode::Exception, FailureMode::Log, new RecordingLogger());
+        $request    = new ServerRequest('GET', '/v1/roster'); // missing required page + X-Client
+
+        $this->expectException(ContractViolationException::class);
+        $middleware->process($request, $this->handlerReturning(new Response(200)));
+    }
+
+    public function test_response_violation_uses_response_mode(): void
+    {
+        // request=Log so the (also-invalid) request only logs; response=Exception throws on the bad body.
+        $logger     = new RecordingLogger();
+        $middleware = $this->makeMiddleware(FailureMode::Log, FailureMode::Exception, $logger);
+        $request    = (new ServerRequest('GET', '/v1/roster'))
+            ->withQueryParams(['page' => '1'])
+            ->withHeader('X-Client', 'abc');
+
+        $badResponse = (new Response(200))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(\Nyholm\Psr7\Stream::create('{"not":"an-array"}')); // schema expects array
+
+        try {
+            $middleware->process($request, $this->handlerReturning($badResponse));
+            $this->fail('Expected ContractViolationException for the response violation');
+        } catch (ContractViolationException $e) {
+            $this->assertSame('response', $e->direction->value);
+        }
+    }
+}

--- a/tests/Feature/ContractValidatorTest.php
+++ b/tests/Feature/ContractValidatorTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Fissible\Accord\Tests\Feature;
 
 use Fissible\Accord\ContractValidator;
+use Fissible\Accord\Direction;
 use Fissible\Accord\Exception\ContractViolationException;
 use Fissible\Accord\FailureMode;
 use Fissible\Accord\FileSpecSource;
+use Fissible\Accord\Tests\Support\RecordingLogger;
 use Fissible\Accord\ValidationResult;
 use Fissible\Accord\VersionExtractor;
 use Nyholm\Psr7\Response;
@@ -33,6 +35,67 @@ class ContractValidatorTest extends TestCase
             failureMode:      $mode,
             failureCallable:  $callable,
         );
+    }
+
+    private function makeDirectionalValidator(
+        FailureMode $request,
+        FailureMode $response,
+        RecordingLogger $logger,
+    ): ContractValidator {
+        return new ContractValidator(
+            versionExtractor:    $this->versionExtractor,
+            specSource:          new FileSpecSource($this->fixturesPath, '{base}/{version}'),
+            failureMode:         $request,
+            failureCallable:     null,
+            logger:              $logger,
+            responseFailureMode: $response,
+        );
+    }
+
+    public function test_request_direction_uses_request_mode_and_throws(): void
+    {
+        $validator = $this->makeDirectionalValidator(FailureMode::Exception, FailureMode::Log, new RecordingLogger());
+
+        $this->expectException(ContractViolationException::class);
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Request);
+    }
+
+    public function test_response_direction_uses_response_mode_and_logs(): void
+    {
+        $logger    = new RecordingLogger();
+        $validator = $this->makeDirectionalValidator(FailureMode::Exception, FailureMode::Log, $logger);
+
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
+
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('warning', $logger->records[0]['level']);
+    }
+
+    public function test_log_context_includes_direction(): void
+    {
+        $logger    = new RecordingLogger();
+        $validator = $this->makeDirectionalValidator(FailureMode::Log, FailureMode::Log, $logger);
+
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
+
+        $this->assertSame('response', $logger->records[0]['context']['direction']);
+    }
+
+    public function test_scalar_config_uses_same_mode_for_response_backward_compat(): void
+    {
+        // responseFailureMode null → response falls back to the single failureMode (Log).
+        $logger    = new RecordingLogger();
+        $validator = new ContractValidator(
+            versionExtractor: $this->versionExtractor,
+            specSource:       new FileSpecSource($this->fixturesPath, '{base}/{version}'),
+            failureMode:      FailureMode::Log,
+            failureCallable:  null,
+            logger:           $logger,
+        );
+
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
+
+        $this->assertCount(1, $logger->records);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Feature/LaravelMiddlewareTest.php
+++ b/tests/Feature/LaravelMiddlewareTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Feature;
+
+use Fissible\Accord\ContractValidator;
+use Fissible\Accord\Direction;
+use Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract;
+use Fissible\Accord\Exception\ContractViolationException;
+use Fissible\Accord\FailureMode;
+use Fissible\Accord\FileSpecSource;
+use Fissible\Accord\Tests\Support\RecordingLogger;
+use Fissible\Accord\VersionExtractor;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+class LaravelMiddlewareTest extends TestCase
+{
+    private function makeValidator(
+        FailureMode $request,
+        FailureMode $response,
+        ?RecordingLogger $logger = null,
+    ): ContractValidator {
+        return new ContractValidator(
+            versionExtractor:    new VersionExtractor(),
+            specSource:          new FileSpecSource(dirname(__DIR__) . '/Fixtures', '{base}/{version}'),
+            failureMode:         $request,
+            failureCallable:     null,
+            logger:              $logger ?? new RecordingLogger(),
+            responseFailureMode: $response,
+        );
+    }
+
+    public function test_request_violation_renders_422_json(): void
+    {
+        $middleware = new ValidateApiContract($this->makeValidator(FailureMode::Exception, FailureMode::Log), 422);
+        $request    = Request::create('/v1/roster', 'GET'); // missing required page + X-Client
+
+        $response = $middleware->handle($request, fn () => new JsonResponse([], 200));
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(422, $response->getStatusCode());
+
+        $data = $response->getData(true);
+        $this->assertSame('Request does not satisfy the API contract', $data['message']);
+        $this->assertNotEmpty($data['errors']);
+    }
+
+    public function test_request_violation_status_is_configurable(): void
+    {
+        $middleware = new ValidateApiContract($this->makeValidator(FailureMode::Exception, FailureMode::Log), 418);
+        $request    = Request::create('/v1/roster', 'GET');
+
+        $response = $middleware->handle($request, fn () => new JsonResponse([], 200));
+
+        $this->assertSame(418, $response->getStatusCode());
+    }
+
+    public function test_response_violation_in_log_mode_passes_through(): void
+    {
+        $logger     = new RecordingLogger();
+        $middleware = new ValidateApiContract($this->makeValidator(FailureMode::Exception, FailureMode::Log, $logger), 422);
+
+        $request = Request::create('/v1/roster?page=1', 'GET');
+        $request->headers->set('X-Client', 'abc');
+
+        $original = new JsonResponse(['not' => 'an-array'], 200); // 200 schema expects an array
+        $response = $middleware->handle($request, fn () => $original);
+
+        $this->assertSame($original, $response);            // untouched
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('response', $logger->records[0]['context']['direction']);
+    }
+
+    public function test_response_violation_in_exception_mode_propagates_as_server_error(): void
+    {
+        $middleware = new ValidateApiContract($this->makeValidator(FailureMode::Exception, FailureMode::Exception), 422);
+
+        $request = Request::create('/v1/roster?page=1', 'GET');
+        $request->headers->set('X-Client', 'abc');
+
+        try {
+            $middleware->handle($request, fn () => new JsonResponse(['not' => 'an-array'], 200));
+            $this->fail('Expected the response violation to propagate, not render as a client error');
+        } catch (ContractViolationException $e) {
+            $this->assertSame(Direction::Response, $e->direction);
+        }
+    }
+}

--- a/tests/Feature/LaravelServiceProviderTest.php
+++ b/tests/Feature/LaravelServiceProviderTest.php
@@ -109,67 +109,67 @@ namespace Fissible\Accord\Tests\Feature {
             $this->assertCount(1, $logger->records);
         }
 
-    public function test_array_failure_mode_logs_response_violations(): void
-    {
-        LaravelConfig::$values['accord.failure_mode'] = ['request' => 'exception', 'response' => 'log'];
+        public function test_array_failure_mode_logs_response_violations(): void
+        {
+            LaravelConfig::$values['accord.failure_mode'] = ['request' => 'exception', 'response' => 'log'];
 
-        $logger = new RecordingLogger();
-        $app    = new FakeLaravelContainer([LoggerInterface::class => $logger]);
+            $logger = new RecordingLogger();
+            $app    = new FakeLaravelContainer([LoggerInterface::class => $logger]);
 
-        (new AccordServiceProvider($app))->register();
+            (new AccordServiceProvider($app))->register();
 
-        $validator = $app->make(ContractValidator::class);
-        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
+            $validator = $app->make(ContractValidator::class);
+            $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
 
-        $this->assertCount(1, $logger->records);
-    }
+            $this->assertCount(1, $logger->records);
+        }
 
-    public function test_array_failure_mode_throws_on_request_violations(): void
-    {
-        LaravelConfig::$values['accord.failure_mode'] = ['request' => 'exception', 'response' => 'log'];
+        public function test_array_failure_mode_throws_on_request_violations(): void
+        {
+            LaravelConfig::$values['accord.failure_mode'] = ['request' => 'exception', 'response' => 'log'];
 
-        $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
-        (new AccordServiceProvider($app))->register();
+            $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+            (new AccordServiceProvider($app))->register();
 
-        $validator = $app->make(ContractValidator::class);
+            $validator = $app->make(ContractValidator::class);
 
-        $this->expectException(ContractViolationException::class);
-        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Request);
-    }
+            $this->expectException(ContractViolationException::class);
+            $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Request);
+        }
 
-    public function test_provider_binds_middleware_with_configured_status(): void
-    {
-        LaravelConfig::$values['accord.request_violation_status'] = 418;
+        public function test_provider_binds_middleware_with_configured_status(): void
+        {
+            LaravelConfig::$values['accord.request_violation_status'] = 418;
 
-        $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
-        (new AccordServiceProvider($app))->register();
+            $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+            (new AccordServiceProvider($app))->register();
 
-        $middleware = $app->make(ValidateApiContract::class);
+            $middleware = $app->make(ValidateApiContract::class);
 
-        $this->assertSame(418, $this->readStatus($middleware));
-    }
+            $this->assertSame(418, $this->readStatus($middleware));
+        }
 
-    public function test_provider_casts_string_status_and_guards_non_4xx(): void
-    {
-        $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+        public function test_provider_casts_string_status_and_guards_non_4xx(): void
+        {
+            $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
 
-        LaravelConfig::$values['accord.request_violation_status'] = '418';
-        (new AccordServiceProvider($app))->register();
-        $this->assertSame(418, $this->readStatus($app->make(ValidateApiContract::class)));
+            LaravelConfig::$values['accord.request_violation_status'] = '418';
+            (new AccordServiceProvider($app))->register();
+            $this->assertSame(418, $this->readStatus($app->make(ValidateApiContract::class)));
 
-        // Out-of-4xx falls back to 422. Fresh container so the singleton is rebuilt.
-        $app2 = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
-        LaravelConfig::$values['accord.request_violation_status'] = 500;
-        (new AccordServiceProvider($app2))->register();
-        $this->assertSame(422, $this->readStatus($app2->make(ValidateApiContract::class)));
-    }
+            // Out-of-4xx falls back to 422. Fresh container so the singleton is rebuilt.
+            $app2 = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+            LaravelConfig::$values['accord.request_violation_status'] = 500;
+            (new AccordServiceProvider($app2))->register();
+            $this->assertSame(422, $this->readStatus($app2->make(ValidateApiContract::class)));
+        }
 
-    private function readStatus(ValidateApiContract $middleware): int
-    {
-        $property = new ReflectionProperty(ValidateApiContract::class, 'requestViolationStatus');
+        private function readStatus(ValidateApiContract $middleware): int
+        {
+            $property = new ReflectionProperty(ValidateApiContract::class, 'requestViolationStatus');
 
-        return $property->getValue($middleware);
-    }
+            return $property->getValue($middleware);
+        }
     }
 
     final class LaravelConfig

--- a/tests/Feature/LaravelServiceProviderTest.php
+++ b/tests/Feature/LaravelServiceProviderTest.php
@@ -46,12 +46,16 @@ namespace {
 
 namespace Fissible\Accord\Tests\Feature {
     use Fissible\Accord\ContractValidator;
+    use Fissible\Accord\Direction;
+    use Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract;
     use Fissible\Accord\Drivers\Laravel\Providers\AccordServiceProvider;
+    use Fissible\Accord\Exception\ContractViolationException;
     use Fissible\Accord\ValidationResult;
     use Illuminate\Contracts\Foundation\CachesConfiguration;
     use PHPUnit\Framework\TestCase;
     use Psr\Log\AbstractLogger;
     use Psr\Log\LoggerInterface;
+    use ReflectionProperty;
 
     class LaravelServiceProviderTest extends TestCase
     {
@@ -64,7 +68,8 @@ namespace Fissible\Accord\Tests\Feature {
                 'accord.spec_source'       => 'file',
                 'accord.spec_pattern'      => '{base}/Fixtures/{version}',
                 'accord.spec_cache_ttl'    => 3600,
-                'accord.log_channel'       => null,
+                'accord.log_channel'              => null,
+                'accord.request_violation_status' => 422,
             ];
         }
 
@@ -103,6 +108,68 @@ namespace Fissible\Accord\Tests\Feature {
             $this->assertSame('accord', $logManager->requestedChannel);
             $this->assertCount(1, $logger->records);
         }
+
+    public function test_array_failure_mode_logs_response_violations(): void
+    {
+        LaravelConfig::$values['accord.failure_mode'] = ['request' => 'exception', 'response' => 'log'];
+
+        $logger = new RecordingLogger();
+        $app    = new FakeLaravelContainer([LoggerInterface::class => $logger]);
+
+        (new AccordServiceProvider($app))->register();
+
+        $validator = $app->make(ContractValidator::class);
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Response);
+
+        $this->assertCount(1, $logger->records);
+    }
+
+    public function test_array_failure_mode_throws_on_request_violations(): void
+    {
+        LaravelConfig::$values['accord.failure_mode'] = ['request' => 'exception', 'response' => 'log'];
+
+        $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+        (new AccordServiceProvider($app))->register();
+
+        $validator = $app->make(ContractValidator::class);
+
+        $this->expectException(ContractViolationException::class);
+        $validator->handleFailure(ValidationResult::invalid(['bad'], 'v1'), Direction::Request);
+    }
+
+    public function test_provider_binds_middleware_with_configured_status(): void
+    {
+        LaravelConfig::$values['accord.request_violation_status'] = 418;
+
+        $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+        (new AccordServiceProvider($app))->register();
+
+        $middleware = $app->make(ValidateApiContract::class);
+
+        $this->assertSame(418, $this->readStatus($middleware));
+    }
+
+    public function test_provider_casts_string_status_and_guards_non_4xx(): void
+    {
+        $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+
+        LaravelConfig::$values['accord.request_violation_status'] = '418';
+        (new AccordServiceProvider($app))->register();
+        $this->assertSame(418, $this->readStatus($app->make(ValidateApiContract::class)));
+
+        // Out-of-4xx falls back to 422. Fresh container so the singleton is rebuilt.
+        $app2 = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+        LaravelConfig::$values['accord.request_violation_status'] = 500;
+        (new AccordServiceProvider($app2))->register();
+        $this->assertSame(422, $this->readStatus($app2->make(ValidateApiContract::class)));
+    }
+
+    private function readStatus(ValidateApiContract $middleware): int
+    {
+        $property = new ReflectionProperty(ValidateApiContract::class, 'requestViolationStatus');
+
+        return $property->getValue($middleware);
+    }
     }
 
     final class LaravelConfig

--- a/tests/Feature/LaravelServiceProviderTest.php
+++ b/tests/Feature/LaravelServiceProviderTest.php
@@ -48,6 +48,7 @@ namespace Fissible\Accord\Tests\Feature {
     use Fissible\Accord\ContractValidator;
     use Fissible\Accord\Drivers\Laravel\Providers\AccordServiceProvider;
     use Fissible\Accord\ValidationResult;
+    use Illuminate\Contracts\Foundation\CachesConfiguration;
     use PHPUnit\Framework\TestCase;
     use Psr\Log\AbstractLogger;
     use Psr\Log\LoggerInterface;
@@ -117,7 +118,14 @@ namespace Fissible\Accord\Tests\Feature {
         }
     }
 
-    final class FakeLaravelContainer
+    /**
+     * Minimal container double. Implements CachesConfiguration (reporting the config
+     * as "cached") so the real Illuminate\Support\ServiceProvider::mergeConfigFrom —
+     * pulled in once illuminate/http became a dev dependency — short-circuits instead
+     * of requiring the real config file. Provider config reads go through the global
+     * config() stub (LaravelConfig) below, not this container.
+     */
+    final class FakeLaravelContainer implements CachesConfiguration
     {
         /** @var array<string, mixed> */
         private array $instances;
@@ -129,6 +137,21 @@ namespace Fissible\Accord\Tests\Feature {
         public function __construct(array $instances = [])
         {
             $this->instances = $instances;
+        }
+
+        public function configurationIsCached(): bool
+        {
+            return true;
+        }
+
+        public function getCachedConfigPath(): string
+        {
+            return '';
+        }
+
+        public function getCachedServicesPath(): string
+        {
+            return '';
         }
 
         public function singleton(string $abstract, callable $factory): void

--- a/tests/Feature/LaravelServiceProviderTest.php
+++ b/tests/Feature/LaravelServiceProviderTest.php
@@ -50,10 +50,10 @@ namespace Fissible\Accord\Tests\Feature {
     use Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract;
     use Fissible\Accord\Drivers\Laravel\Providers\AccordServiceProvider;
     use Fissible\Accord\Exception\ContractViolationException;
+    use Fissible\Accord\Tests\Support\RecordingLogger;
     use Fissible\Accord\ValidationResult;
     use Illuminate\Contracts\Foundation\CachesConfiguration;
     use PHPUnit\Framework\TestCase;
-    use Psr\Log\AbstractLogger;
     use Psr\Log\LoggerInterface;
     use ReflectionProperty;
 
@@ -253,21 +253,6 @@ namespace Fissible\Accord\Tests\Feature {
             $this->requestedChannel = $channel;
 
             return $this->logger;
-        }
-    }
-
-    final class RecordingLogger extends AbstractLogger
-    {
-        /** @var array<int, array{level: string, message: string, context: array<string, mixed>}> */
-        public array $records = [];
-
-        public function log($level, string|\Stringable $message, array $context = []): void
-        {
-            $this->records[] = [
-                'level'   => (string) $level,
-                'message' => (string) $message,
-                'context' => $context,
-            ];
         }
     }
 }

--- a/tests/Support/RecordingLogger.php
+++ b/tests/Support/RecordingLogger.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Support;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+final class RecordingLogger extends AbstractLogger
+{
+    /** @var array<int, array{level: string, message: string, context: array<string, mixed>}> */
+    public array $records = [];
+
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level'   => (string) $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/tests/Unit/AccordFactoryTest.php
+++ b/tests/Unit/AccordFactoryTest.php
@@ -66,4 +66,24 @@ class AccordFactoryTest extends TestCase
 
         $this->assertInstanceOf(AccordMiddleware::class, $middleware);
     }
+
+    public function test_make_accepts_array_failure_mode_without_error(): void
+    {
+        $middleware = AccordFactory::make(
+            ['failure_mode' => ['request' => 'exception', 'response' => 'log']],
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        $this->assertInstanceOf(AccordMiddleware::class, $middleware);
+    }
+
+    public function test_make_still_accepts_scalar_failure_mode(): void
+    {
+        $middleware = AccordFactory::make(
+            ['failure_mode' => 'log'],
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        $this->assertInstanceOf(AccordMiddleware::class, $middleware);
+    }
 }

--- a/tests/Unit/ContractViolationExceptionTest.php
+++ b/tests/Unit/ContractViolationExceptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Unit;
+
+use Fissible\Accord\Direction;
+use Fissible\Accord\Exception\ContractViolationException;
+use Fissible\Accord\ValidationResult;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ContractViolationExceptionTest extends TestCase
+{
+    public function test_defaults_to_request_direction(): void
+    {
+        $e = new ContractViolationException(ValidationResult::invalid(['x'], 'v1'));
+
+        $this->assertSame(Direction::Request, $e->direction);
+    }
+
+    public function test_carries_supplied_direction(): void
+    {
+        $e = new ContractViolationException(
+            ValidationResult::invalid(['x'], 'v1'),
+            direction: Direction::Response,
+        );
+
+        $this->assertSame(Direction::Response, $e->direction);
+    }
+
+    public function test_preserves_legacy_positional_abi(): void
+    {
+        $previous = new RuntimeException('root');
+
+        $e = new ContractViolationException(
+            ValidationResult::invalid(['x'], 'v1'),
+            'custom message',
+            42,
+            $previous,
+        );
+
+        $this->assertSame('custom message', $e->getMessage());
+        $this->assertSame(42, $e->getCode());
+        $this->assertSame($previous, $e->getPrevious());
+        $this->assertSame(Direction::Request, $e->direction);
+    }
+}

--- a/tests/Unit/DirectionTest.php
+++ b/tests/Unit/DirectionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Unit;
+
+use Fissible\Accord\Direction;
+use PHPUnit\Framework\TestCase;
+
+class DirectionTest extends TestCase
+{
+    public function test_backing_values_are_stable_strings(): void
+    {
+        $this->assertSame('request', Direction::Request->value);
+        $this->assertSame('response', Direction::Response->value);
+    }
+}

--- a/tests/Unit/FailureModeTest.php
+++ b/tests/Unit/FailureModeTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Unit;
+
+use Fissible\Accord\FailureMode;
+use PHPUnit\Framework\TestCase;
+use ValueError;
+
+class FailureModeTest extends TestCase
+{
+    public function test_scalar_applies_to_both_directions(): void
+    {
+        $this->assertSame([FailureMode::Log, FailureMode::Log], FailureMode::resolvePair('log'));
+    }
+
+    public function test_full_array_maps_each_direction(): void
+    {
+        $this->assertSame(
+            [FailureMode::Exception, FailureMode::Log],
+            FailureMode::resolvePair(['request' => 'exception', 'response' => 'log']),
+        );
+    }
+
+    public function test_missing_response_key_falls_back_to_request(): void
+    {
+        $this->assertSame(
+            [FailureMode::Log, FailureMode::Log],
+            FailureMode::resolvePair(['request' => 'log']),
+        );
+    }
+
+    public function test_missing_request_key_falls_back_to_exception_default(): void
+    {
+        $this->assertSame(
+            [FailureMode::Exception, FailureMode::Log],
+            FailureMode::resolvePair(['response' => 'log']),
+        );
+    }
+
+    public function test_empty_array_falls_back_to_exception(): void
+    {
+        $this->assertSame(
+            [FailureMode::Exception, FailureMode::Exception],
+            FailureMode::resolvePair([]),
+        );
+    }
+
+    public function test_null_falls_back_to_exception(): void
+    {
+        $this->assertSame(
+            [FailureMode::Exception, FailureMode::Exception],
+            FailureMode::resolvePair(null),
+        );
+    }
+
+    public function test_unknown_scalar_throws(): void
+    {
+        $this->expectException(ValueError::class);
+        FailureMode::resolvePair('bogus');
+    }
+
+    public function test_blank_scalar_throws(): void
+    {
+        $this->expectException(ValueError::class);
+        FailureMode::resolvePair('');
+    }
+
+    public function test_present_but_unknown_array_value_throws(): void
+    {
+        $this->expectException(ValueError::class);
+        FailureMode::resolvePair(['request' => 'nope']);
+    }
+}


### PR DESCRIPTION
Implements **#5** (per-direction failure modes) and **#6** (HTTP-aware rendering). Fully backward compatible — `fissible/accord` is at v1.0.0, so this is purely additive.

## Summary

- **`failure_mode` accepts a string OR an array.** A scalar applies to both directions; `['request' => 'exception', 'response' => 'log']` sets each independently. Parsed by one shared `FailureMode::resolvePair`, used by both `AccordFactory` (Slim/Mezzio) and the Laravel provider so parsing never diverges. A missing array key falls back (response→request, request→exception default); a present-but-unknown mode still throws `ValueError`.
- **Direction-aware `ContractValidator::handleFailure(result, Direction)`** — request vs response select their own mode; log context now includes `direction` for observability.
- **`ContractViolationException` carries `direction`** as a *trailing* constructor param, preserving the existing positional ABI.
- **Laravel rendering (#6):** a request violation under exception mode renders as JSON `{ message, errors }` at `request_violation_status` (default `422`; non-4xx values fall back to `422`). A response violation is treated as a server-side problem — under exception mode it propagates (500), under log mode it is logged and the original response passes through unchanged. It is **never** rendered as a client 4xx.
- The provider **explicitly binds** `ValidateApiContract` with the resolved status, so the config override actually applies (a primitive constructor default would otherwise be silently autowired).
- The framework-agnostic core is preserved: no `Illuminate\` references outside `src/Drivers/`.

## Backward compatibility

Scalar `failure_mode` behaves exactly as before for both directions (`responseFailureMode` defaults to the single mode). New constructor/method params are all optional trailing additions. Locked by explicit regression tests (legacy exception ABI; scalar-config response handling).

## Notable

`illuminate/http` was added to `require-dev` so the Laravel middleware tests exercise real `Request`/`JsonResponse` objects. That pulled in the real `Illuminate\Support\ServiceProvider`, so the provider test's fake container now implements `CachesConfiguration` (reporting cached) to short-circuit `mergeConfigFrom` — documented inline.

## Test plan

- [x] `vendor/bin/phpunit` — **89 tests pass** (was 60), 5 pre-existing `cebe/php-openapi` deprecations, none new
- [x] `git diff --check` clean
- [x] No `Illuminate\` references outside `src/Drivers/` (core stays framework-agnostic)
- [x] Backward-compat traced and test-locked for scalar config + exception ABI

Design spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)