### PR TITLE
feat: runtime validation options — exclusions, sampling, response toggle (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ return [
     'log_channel'    => env('ACCORD_LOG_CHANNEL'),               // null = default logger
     'request_violation_status' => env('ACCORD_REQUEST_VIOLATION_STATUS', 422), // request 4xx; non-4xx → 422
     'debug'          => env('ACCORD_DEBUG', false), // log skipped (non-validated) requests/responses + why
+    'exclude'              => [],                                  // glob patterns; matched routes skip all validation
+    'validate_responses'   => env('ACCORD_VALIDATE_RESPONSES', true),    // false = don't validate responses (requests still validated)
+    'response_sample_rate' => env('ACCORD_RESPONSE_SAMPLE_RATE', 1.0),   // fraction of responses to validate (0.0–1.0)
     'failure_callable' => null,
     'version_pattern'  => '/^\/v(\d+)(?:\/|$)/',
     'spec_source'    => env('ACCORD_SPEC_SOURCE', 'file'),       // file | url
@@ -289,6 +292,26 @@ return [
     'spec_cache_ttl' => env('ACCORD_SPEC_CACHE_TTL', 3600),
 ];
 ```
+
+**Running it in production — controlling overhead.** Response validation runs on every
+response by default. Three knobs let you keep it cheap:
+
+- **`exclude`** — glob patterns (`*` matches any characters, including `/`). Matched routes
+  skip *all* validation, request and response (e.g. `['/v2/health', '/v2/internal/*',
+  '*/metrics']`). Cost: those routes aren't contract-checked at all.
+- **`validate_responses => false`** — stop validating responses while still validating
+  requests. Cost: response drift goes uncaught at runtime — rely on the
+  `AssertsApiContracts` CI checks instead.
+- **`response_sample_rate`** — validate only a fraction of responses (e.g. `0.1` ≈ 10%).
+  Trades coverage for throughput on hot or large-payload endpoints; out-of-range values are
+  clamped to `0.0..1.0`.
+
+These show up in `ACCORD_DEBUG` output as `excluded`, `response_validation_disabled`, and
+`not_sampled` skips, and as `wasValidated() === false`. **Note:** with `validate_responses`
+off (or a very low sample rate) *and* `ACCORD_DEBUG` on, debug logs *every* response as a
+skip — that's expected for a diagnostic mode, but don't run that combination in steady
+state. (For the Slim/Mezzio `AccordFactory`, remember debug logging only produces output
+when you pass a `logger` config key — the Laravel driver injects one automatically.)
 
 **Diagnostics — "was anything actually validated?"** Accord fails open by design (a
 missing spec, unmatched route, or undeclared schema all pass), which can hide the fact

--- a/docs/superpowers/plans/2026-06-15-runtime-validation-options.md
+++ b/docs/superpowers/plans/2026-06-15-runtime-validation-options.md
@@ -1,0 +1,976 @@
+# Runtime Validation Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users exclude routes, sample responses, and toggle response validation off — to run Accord's runtime middleware cheaply in production.
+
+**Architecture:** A new framework-agnostic `RuntimeOptions` value object holds the policy; `ContractValidator` consults it as *early skips* (before loading the spec), returning new `SkipReason`s (`Excluded`, `ResponseValidationDisabled`, `NotSampled`). Because a skip is `valid=true`, both middlewares already pass that traffic through unchanged — and #9's `ACCORD_DEBUG`/`wasValidated()` report the skips for free.
+
+**Tech Stack:** PHP 8.2+, PHPUnit 11, cebe/php-openapi, nyholm/psr7, illuminate/http (dev).
+
+**Spec:** `docs/superpowers/specs/2026-06-15-runtime-validation-options-design.md`
+
+**Branch:** `feat/runtime-options` (already checked out).
+
+**Conventions:** `declare(strict_types=1)` everywhere; no public non-readonly props; framework code only under `src/Drivers/`. `SkipReason`, `Direction`, `RuntimeOptions`, `ValidationResult`, `FailureMode` are all in namespace `Fissible\Accord` — code inside `src/*.php` references them with NO `use`. Run the suite with `vendor/bin/phpunit --colors=never`. **Baseline: 114 tests passing, 5 pre-existing cebe deprecations** — the count must stay 5.
+
+---
+
+## File Structure
+
+**Core (create):** `src/RuntimeOptions.php` — the exclude/sample/toggle policy + glob matching + sampling decision.
+
+**Core (modify):**
+- `src/SkipReason.php` — add `Excluded`, `ResponseValidationDisabled`, `NotSampled`.
+- `src/ContractValidator.php` — trailing `RuntimeOptions $runtimeOptions` ctor param + early gates in `validateRequest`/`validateResponse`.
+- `src/AccordFactory.php` — build `RuntimeOptions` from config; docblock.
+
+**Laravel driver (modify):**
+- `src/Drivers/Laravel/config/accord.php` — `exclude` / `validate_responses` / `response_sample_rate` (documented).
+- `src/Drivers/Laravel/Providers/AccordServiceProvider.php` — build + pass `RuntimeOptions`.
+
+**Tests (create):** `tests/Unit/RuntimeOptionsTest.php`.
+**Tests (modify):** `tests/Unit/SkipReasonTest.php`, `tests/Feature/ContractValidatorTest.php`, `tests/Feature/LaravelServiceProviderTest.php`, `tests/Unit/AccordFactoryTest.php`.
+**Docs (modify):** `README.md`.
+
+---
+
+## Task 1: `SkipReason` — three runtime-gate reasons
+
+**Files:**
+- Modify: `src/SkipReason.php`
+- Test: `tests/Unit/SkipReasonTest.php`
+
+The current enum has six cases (`Unversioned` … `UnsupportedMediaType`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add this method to the existing `SkipReasonTest` class in `tests/Unit/SkipReasonTest.php`:
+
+```php
+    public function test_runtime_gate_backing_values(): void
+    {
+        $this->assertSame('excluded', SkipReason::Excluded->value);
+        $this->assertSame('response_validation_disabled', SkipReason::ResponseValidationDisabled->value);
+        $this->assertSame('not_sampled', SkipReason::NotSampled->value);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter SkipReasonTest`
+Expected: FAIL — `Undefined constant Fissible\Accord\SkipReason::Excluded`.
+
+- [ ] **Step 3: Add the three cases**
+
+Replace the entire contents of `src/SkipReason.php` with:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord;
+
+enum SkipReason: string
+{
+    case Unversioned                = 'unversioned';
+    case MissingSpec                = 'missing_spec';
+    case UnmatchedOperation         = 'unmatched_operation';
+    case MissingRequestSchema       = 'missing_request_schema';
+    case MissingResponseSchema      = 'missing_response_schema';
+    case UnsupportedMediaType       = 'unsupported_media_type';
+    case Excluded                   = 'excluded';
+    case ResponseValidationDisabled = 'response_validation_disabled';
+    case NotSampled                 = 'not_sampled';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter SkipReasonTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/SkipReason.php tests/Unit/SkipReasonTest.php
+git commit -m "feat: add runtime-gate skip reasons (excluded/response-disabled/not-sampled) (#8)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `RuntimeOptions` value object
+
+**Files:**
+- Create: `src/RuntimeOptions.php`
+- Test: `tests/Unit/RuntimeOptionsTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Unit/RuntimeOptionsTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Unit;
+
+use Fissible\Accord\RuntimeOptions;
+use PHPUnit\Framework\TestCase;
+
+class RuntimeOptionsTest extends TestCase
+{
+    public function test_exact_path_is_excluded(): void
+    {
+        $this->assertTrue((new RuntimeOptions(['/v2/health']))->isExcluded('/v2/health'));
+    }
+
+    public function test_non_matching_path_is_not_excluded(): void
+    {
+        $this->assertFalse((new RuntimeOptions(['/v2/health']))->isExcluded('/v2/users'));
+    }
+
+    public function test_empty_exclusions_never_match(): void
+    {
+        $this->assertFalse((new RuntimeOptions())->isExcluded('/v2/anything'));
+    }
+
+    public function test_star_matches_across_slashes(): void
+    {
+        $options = new RuntimeOptions(['/v2/internal/*']);
+
+        $this->assertTrue($options->isExcluded('/v2/internal/a/b/c'));
+        $this->assertFalse($options->isExcluded('/v2/public/x'));
+    }
+
+    public function test_leading_star_matches_any_version(): void
+    {
+        $this->assertTrue((new RuntimeOptions(['*/metrics']))->isExcluded('/v9/metrics'));
+    }
+
+    public function test_validates_responses_reflects_flag(): void
+    {
+        $this->assertTrue((new RuntimeOptions(validateResponses: true))->validatesResponses());
+        $this->assertFalse((new RuntimeOptions(validateResponses: false))->validatesResponses());
+    }
+
+    public function test_rate_above_one_is_clamped_to_always_sample(): void
+    {
+        $options = new RuntimeOptions(
+            responseSampleRate: 2.0,
+            sampler: fn (): float => throw new \RuntimeException('sampler must not be consulted at rate 1.0'),
+        );
+
+        $this->assertTrue($options->shouldSampleResponse());
+    }
+
+    public function test_rate_below_zero_is_clamped_to_never_sample(): void
+    {
+        $options = new RuntimeOptions(
+            responseSampleRate: -1.0,
+            sampler: fn (): float => throw new \RuntimeException('sampler must not be consulted at rate 0.0'),
+        );
+
+        $this->assertFalse($options->shouldSampleResponse());
+    }
+
+    public function test_draw_below_rate_is_sampled_in(): void
+    {
+        $options = new RuntimeOptions(responseSampleRate: 0.5, sampler: fn (): float => 0.3);
+
+        $this->assertTrue($options->shouldSampleResponse());
+    }
+
+    public function test_draw_at_or_above_rate_is_sampled_out(): void
+    {
+        $options = new RuntimeOptions(responseSampleRate: 0.5, sampler: fn (): float => 0.7);
+
+        $this->assertFalse($options->shouldSampleResponse());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter RuntimeOptionsTest`
+Expected: FAIL — `Class "Fissible\Accord\RuntimeOptions" not found`.
+
+- [ ] **Step 3: Write the value object**
+
+Create `src/RuntimeOptions.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord;
+
+use Closure;
+
+/**
+ * Runtime validation policy: which routes to skip, whether to validate responses,
+ * and what fraction of responses to sample. Permissive defaults reproduce
+ * "validate everything" behavior.
+ */
+final class RuntimeOptions
+{
+    private readonly float $responseSampleRate;
+
+    /** @var Closure(): float */
+    private readonly Closure $sampler;
+
+    /**
+     * @param string[]      $excludedPaths      glob patterns; '*' matches any chars including '/'
+     * @param bool          $validateResponses  validate responses (requests are always validated unless excluded)
+     * @param float         $responseSampleRate fraction 0.0–1.0 of responses to validate (clamped, never throws)
+     * @param Closure(): float|null $sampler    test seam: a draw source returning a float in [0,1]
+     */
+    public function __construct(
+        private readonly array $excludedPaths = [],
+        private readonly bool $validateResponses = true,
+        float $responseSampleRate = 1.0,
+        ?Closure $sampler = null,
+    ) {
+        $this->responseSampleRate = max(0.0, min(1.0, $responseSampleRate));
+        $this->sampler            = $sampler ?? static fn (): float => mt_rand() / mt_getrandmax();
+    }
+
+    public function isExcluded(string $path): bool
+    {
+        foreach ($this->excludedPaths as $pattern) {
+            $regex = '#^' . str_replace('\*', '.*', preg_quote($pattern, '#')) . '$#';
+
+            if (preg_match($regex, $path) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function validatesResponses(): bool
+    {
+        return $this->validateResponses;
+    }
+
+    public function shouldSampleResponse(): bool
+    {
+        if ($this->responseSampleRate >= 1.0) {
+            return true;
+        }
+
+        if ($this->responseSampleRate <= 0.0) {
+            return false;
+        }
+
+        return ($this->sampler)() < $this->responseSampleRate;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit --filter RuntimeOptionsTest`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/RuntimeOptions.php tests/Unit/RuntimeOptionsTest.php
+git commit -m "feat: add RuntimeOptions (glob exclusions, response toggle, sampling) (#8)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `ContractValidator` — early runtime gates
+
+**Files:**
+- Modify: `src/ContractValidator.php`
+- Test: `tests/Feature/ContractValidatorTest.php`
+
+This reuses the `tests/Fixtures/v2.yaml` fixture already created in #9 (`/v2/items` GET returns a `200` array; etc.).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `use Fissible\Accord\RuntimeOptions;` to the imports of `tests/Feature/ContractValidatorTest.php` (it already imports `SkipReason`, `Direction`, `RecordingLogger`, `ContractValidator`, `FileSpecSource`, `Response`, `ServerRequest`, etc.). Add this helper and the tests inside the class:
+
+```php
+    private function makeOptionsValidator(
+        RuntimeOptions $options,
+        ?RecordingLogger $logger = null,
+        bool $debug = false,
+    ): ContractValidator {
+        return new ContractValidator(
+            versionExtractor: $this->versionExtractor,
+            specSource:       new FileSpecSource($this->fixturesPath, '{base}/{version}'),
+            logger:           $logger ?? new RecordingLogger(),
+            debug:            $debug,
+            runtimeOptions:   $options,
+        );
+    }
+
+    // --- runtime options: exclusions / toggle / sampling (#8) ---
+
+    public function test_excluded_request_is_skipped(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/v2/items']));
+
+        $result = $validator->validateRequest(new ServerRequest('GET', '/v2/items'));
+
+        $this->assertSame(SkipReason::Excluded, $result->skipReason);
+        $this->assertFalse($result->wasValidated());
+    }
+
+    public function test_excluded_response_is_skipped(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/v2/items']));
+
+        $result = $validator->validateResponse(
+            $this->jsonResponse(200, '[]'),
+            new ServerRequest('GET', '/v2/items'),
+        );
+
+        $this->assertSame(SkipReason::Excluded, $result->skipReason);
+    }
+
+    public function test_exclusion_takes_precedence_over_unversioned(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/health']));
+
+        $result = $validator->validateRequest(new ServerRequest('GET', '/health'));
+
+        $this->assertSame(SkipReason::Excluded, $result->skipReason);
+    }
+
+    public function test_exclusion_short_circuits_before_spec_load(): void
+    {
+        // /v99 has no spec; exclusion must win (Excluded, not MissingSpec).
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/v99/*']));
+
+        $result = $validator->validateRequest(new ServerRequest('GET', '/v99/items'));
+
+        $this->assertSame(SkipReason::Excluded, $result->skipReason);
+    }
+
+    public function test_response_validation_disabled_skips_response(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(validateResponses: false));
+
+        // A response that would otherwise validate (GET /v2/items 200 array).
+        $result = $validator->validateResponse(
+            $this->jsonResponse(200, '[]'),
+            new ServerRequest('GET', '/v2/items'),
+        );
+
+        $this->assertSame(SkipReason::ResponseValidationDisabled, $result->skipReason);
+    }
+
+    public function test_request_still_validated_when_responses_disabled(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(validateResponses: false));
+
+        // GET /v2/items/5 has an evaluated path param → request is validated regardless.
+        $result = $validator->validateRequest(new ServerRequest('GET', '/v2/items/5'));
+
+        $this->assertTrue($result->wasValidated());
+    }
+
+    public function test_response_sampled_out_is_skipped(): void
+    {
+        $validator = $this->makeOptionsValidator(
+            new RuntimeOptions(responseSampleRate: 0.5, sampler: fn (): float => 0.7),
+        );
+
+        $result = $validator->validateResponse(
+            $this->jsonResponse(200, '[]'),
+            new ServerRequest('GET', '/v2/items'),
+        );
+
+        $this->assertSame(SkipReason::NotSampled, $result->skipReason);
+    }
+
+    public function test_response_sampled_in_is_validated(): void
+    {
+        $validator = $this->makeOptionsValidator(
+            new RuntimeOptions(responseSampleRate: 0.5, sampler: fn (): float => 0.3),
+        );
+
+        $result = $validator->validateResponse(
+            $this->jsonResponse(200, '[]'),
+            new ServerRequest('GET', '/v2/items'),
+        );
+
+        $this->assertTrue($result->wasValidated());
+        $this->assertTrue($result->valid);
+    }
+
+    public function test_debug_logs_excluded_skip(): void
+    {
+        $logger    = new RecordingLogger();
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/v2/items']), $logger, debug: true);
+
+        $validator->validateRequest(new ServerRequest('GET', '/v2/items'));
+
+        $this->assertSame('excluded', $logger->records[0]['context']['reason']);
+        $this->assertSame('request', $logger->records[0]['context']['direction']);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter ContractValidatorTest`
+Expected: FAIL — `runtimeOptions` is not a known named parameter.
+
+- [ ] **Step 3: Add the ctor param and the gates**
+
+(a) In `src/ContractValidator.php`, add the trailing `runtimeOptions` param (keep the existing seven params unchanged):
+
+```php
+    public function __construct(
+        private readonly VersionExtractor $versionExtractor,
+        private readonly SpecSourceInterface $specSource,
+        private readonly FailureMode $failureMode = FailureMode::Exception,
+        /** @var callable(ValidationResult): void|null */
+        private readonly mixed $failureCallable = null,
+        private readonly LoggerInterface $logger = new NullLogger(),
+        private readonly ?FailureMode $responseFailureMode = null,
+        private readonly bool $debug = false,
+        private readonly RuntimeOptions $runtimeOptions = new RuntimeOptions(),
+    ) {}
+```
+
+(b) Replace the WHOLE `validateRequest` method with (note `$path` now extracted up front, and the exclusion gate added before the version check):
+
+```php
+    public function validateRequest(ServerRequestInterface $request): ValidationResult
+    {
+        $version = $this->versionExtractor->extract($request);
+        $path    = $request->getUri()->getPath();
+
+        if ($this->runtimeOptions->isExcluded($path)) {
+            return $this->skip(SkipReason::Excluded, $version ?? 'unversioned', $request, Direction::Request);
+        }
+
+        if ($version === null) {
+            return $this->skip(SkipReason::Unversioned, 'unversioned', $request, Direction::Request);
+        }
+
+        $spec = $this->loadSpec($version);
+
+        if ($spec === null) {
+            return $this->skip(SkipReason::MissingSpec, $version, $request, Direction::Request);
+        }
+
+        $method = strtolower($request->getMethod());
+        $match  = $this->findPathItem($spec, $path);
+
+        if ($match === null) {
+            return $this->skip(SkipReason::UnmatchedOperation, $version, $request, Direction::Request);
+        }
+
+        $operation = $match['pathItem']->getOperations()[$method] ?? null;
+
+        if ($operation === null) {
+            return $this->skip(SkipReason::UnmatchedOperation, $version, $request, Direction::Request);
+        }
+
+        [$paramErrors, $paramsEvaluated] = $this->validateParameters(
+            $operation,
+            $match['pathItem'],
+            $match['template'],
+            $request,
+        );
+
+        $bodySchema = null;
+        $bodySkip   = SkipReason::MissingRequestSchema;
+
+        if ($operation->requestBody !== null) {
+            $contentType = $this->parseContentType($request->getHeaderLine('Content-Type'));
+            $mediaType   = $operation->requestBody->content[$contentType] ?? null;
+
+            if ($mediaType === null) {
+                $bodySkip = SkipReason::UnsupportedMediaType;
+            } elseif ($mediaType->schema === null) {
+                $bodySkip = SkipReason::MissingRequestSchema;
+            } else {
+                $bodySchema = $mediaType->schema;
+            }
+        }
+
+        if ($paramsEvaluated === 0 && $bodySchema === null) {
+            return $this->skip($bodySkip, $version, $request, Direction::Request);
+        }
+
+        $errors = $paramErrors;
+
+        if ($bodySchema !== null) {
+            $errors = array_merge($errors, $this->validateJsonBody((string) $request->getBody(), $bodySchema));
+        }
+
+        return empty($errors)
+            ? ValidationResult::valid($version)
+            : ValidationResult::invalid($errors, $version);
+    }
+```
+
+(c) Replace the WHOLE `validateResponse` method with (exclusion → response-disabled → not-sampled gates added before the version check, all before spec load):
+
+```php
+    public function validateResponse(ResponseInterface $response, ServerRequestInterface $request): ValidationResult
+    {
+        $version  = $this->versionExtractor->extract($request);
+        $path     = $request->getUri()->getPath();
+        $fallback = $version ?? 'unversioned';
+
+        if ($this->runtimeOptions->isExcluded($path)) {
+            return $this->skip(SkipReason::Excluded, $fallback, $request, Direction::Response);
+        }
+
+        if (!$this->runtimeOptions->validatesResponses()) {
+            return $this->skip(SkipReason::ResponseValidationDisabled, $fallback, $request, Direction::Response);
+        }
+
+        if (!$this->runtimeOptions->shouldSampleResponse()) {
+            return $this->skip(SkipReason::NotSampled, $fallback, $request, Direction::Response);
+        }
+
+        if ($version === null) {
+            return $this->skip(SkipReason::Unversioned, 'unversioned', $request, Direction::Response);
+        }
+
+        $spec = $this->loadSpec($version);
+
+        if ($spec === null) {
+            return $this->skip(SkipReason::MissingSpec, $version, $request, Direction::Response);
+        }
+
+        $method    = strtolower($request->getMethod());
+        $operation = $this->findOperation($spec, $method, $path);
+
+        if ($operation === null) {
+            return $this->skip(SkipReason::UnmatchedOperation, $version, $request, Direction::Response);
+        }
+
+        if ($operation->responses === null) {
+            return $this->skip(SkipReason::MissingResponseSchema, $version, $request, Direction::Response);
+        }
+
+        $statusCode   = (string) $response->getStatusCode();
+        $specResponse = $operation->responses->getResponse($statusCode)
+            ?? $operation->responses->getResponse('default');
+
+        if ($specResponse === null) {
+            return $this->skip(SkipReason::MissingResponseSchema, $version, $request, Direction::Response);
+        }
+
+        $contentType = $this->parseContentType($response->getHeaderLine('Content-Type'));
+        $mediaType   = $specResponse->content[$contentType] ?? null;
+
+        if ($mediaType === null) {
+            return $this->skip(SkipReason::UnsupportedMediaType, $version, $request, Direction::Response);
+        }
+
+        if ($mediaType->schema === null) {
+            return $this->skip(SkipReason::MissingResponseSchema, $version, $request, Direction::Response);
+        }
+
+        $body   = (string) $response->getBody();
+        $errors = $this->validateJsonBody($body, $mediaType->schema);
+
+        return empty($errors)
+            ? ValidationResult::valid($version)
+            : ValidationResult::invalid($errors, $version);
+    }
+```
+
+`RuntimeOptions`, `SkipReason`, `Direction` are all in the same `Fissible\Accord` namespace — do NOT add `use` statements. Do not change any other method.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS. 114 prior + 1 (Task 1) + 10 (Task 2) + 9 (Task 3) = 134 tests. Deprecations remain 5. The existing #9 skip tests still pass (their validators use the permissive default `RuntimeOptions`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ContractValidator.php tests/Feature/ContractValidatorTest.php
+git commit -m "feat: ContractValidator applies runtime gates (exclude/toggle/sample) as early skips (#8)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Laravel config — exclude / validate_responses / response_sample_rate
+
+**Files:**
+- Modify: `src/Drivers/Laravel/config/accord.php`
+
+No isolated test (config data); exercised by Task 5.
+
+- [ ] **Step 1: Add the three blocks**
+
+In `src/Drivers/Laravel/config/accord.php`, add these blocks immediately before the final closing `];` (after the existing `debug` key):
+
+```php
+
+    /*
+    |--------------------------------------------------------------------------
+    | Route Exclusions
+    |--------------------------------------------------------------------------
+    | Glob patterns matched against the request URI path; '*' matches any
+    | characters, INCLUDING '/'. Matched routes skip BOTH request and response
+    | validation entirely — they are not contract-checked at all. Use only for
+    | routes you deliberately don't cover (health checks, metrics, internal
+    | endpoints), e.g. ['/v2/health', '/v2/internal/*', '*/metrics'].
+    |
+    */
+    'exclude' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validate Responses
+    |--------------------------------------------------------------------------
+    | When false, responses are not validated at runtime but requests still are.
+    | Cost: response/contract drift goes uncaught at runtime — rely on CI
+    | (AssertsApiContracts) to catch it instead. Useful for high-volume APIs
+    | where response validation overhead isn't worth it in production.
+    |
+    */
+    'validate_responses' => env('ACCORD_VALIDATE_RESPONSES', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Response Sample Rate
+    |--------------------------------------------------------------------------
+    | Fraction (0.0–1.0) of responses to validate; the rest pass through
+    | unchecked. Trades response coverage for throughput on hot or large-payload
+    | endpoints. Out-of-range values are clamped (2 -> 1.0, -1 -> 0.0). 1.0
+    | validates every response (default).
+    |
+    */
+    'response_sample_rate' => env('ACCORD_RESPONSE_SAMPLE_RATE', 1.0),
+```
+
+- [ ] **Step 2: Verify syntax + suite**
+
+Run: `php -l src/Drivers/Laravel/config/accord.php` → "No syntax errors detected".
+Run: `vendor/bin/phpunit --colors=never` → 134 tests, 5 deprecations.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Drivers/Laravel/config/accord.php
+git commit -m "feat: Laravel config for exclude/validate_responses/response_sample_rate (#8)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `AccordServiceProvider` builds + passes `RuntimeOptions`
+
+**Files:**
+- Modify: `src/Drivers/Laravel/Providers/AccordServiceProvider.php`
+- Test: `tests/Feature/LaravelServiceProviderTest.php`
+
+The current `ContractValidator` singleton closure ends with:
+
+```php
+            return new ContractValidator(
+                versionExtractor:    $this->app->make(VersionExtractor::class),
+                specSource:          $this->app->make(SpecSourceInterface::class),
+                failureMode:         $requestMode,
+                failureCallable:     $failureCallable,
+                logger:              $this->resolveLogger(),
+                responseFailureMode: $responseMode,
+                debug:               (bool) config('accord.debug', false),
+            );
+```
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/Feature/LaravelServiceProviderTest.php`, add these keys to the `LaravelConfig::$values` array in `setUp()` (next to `accord.debug`):
+
+```php
+                'accord.exclude'               => [],
+                'accord.validate_responses'    => true,
+                'accord.response_sample_rate'  => 1.0,
+```
+
+Add this method to the class (match the existing 8-space method indentation):
+
+```php
+        public function test_exclude_config_skips_validation(): void
+        {
+            LaravelConfig::$values['accord.exclude'] = ['/v99/x'];
+
+            $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+            (new AccordServiceProvider($app))->register();
+
+            $validator = $app->make(ContractValidator::class);
+            $result    = $validator->validateRequest(new ServerRequest('GET', '/v99/x'));
+
+            $this->assertSame(\Fissible\Accord\SkipReason::Excluded, $result->skipReason);
+        }
+```
+
+(`ServerRequest` was imported in #9's Task 5; `SkipReason` is referenced fully-qualified to avoid touching the import block.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter LaravelServiceProviderTest`
+Expected: FAIL — the provider builds a default `RuntimeOptions` (no exclusions), so the request resolves to `MissingSpec`, not `Excluded`.
+
+- [ ] **Step 3: Build RuntimeOptions in the provider**
+
+In `src/Drivers/Laravel/Providers/AccordServiceProvider.php`, add the import near the existing `use` statements:
+
+```php
+use Fissible\Accord\RuntimeOptions;
+```
+
+In the `ContractValidator` singleton closure, add the `runtimeOptions` named argument after `debug:`:
+
+```php
+            return new ContractValidator(
+                versionExtractor:    $this->app->make(VersionExtractor::class),
+                specSource:          $this->app->make(SpecSourceInterface::class),
+                failureMode:         $requestMode,
+                failureCallable:     $failureCallable,
+                logger:              $this->resolveLogger(),
+                responseFailureMode: $responseMode,
+                debug:               (bool) config('accord.debug', false),
+                runtimeOptions:      new RuntimeOptions(
+                    excludedPaths:      config('accord.exclude', []),
+                    validateResponses:  (bool) config('accord.validate_responses', true),
+                    responseSampleRate: (float) config('accord.response_sample_rate', 1.0),
+                ),
+            );
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS. 134 prior + 1 = 135 tests. Deprecations 5. Existing provider tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Drivers/Laravel/Providers/AccordServiceProvider.php tests/Feature/LaravelServiceProviderTest.php
+git commit -m "feat: Laravel provider builds RuntimeOptions from config (#8)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `AccordFactory` builds `RuntimeOptions`
+
+**Files:**
+- Modify: `src/AccordFactory.php`
+- Test: `tests/Unit/AccordFactoryTest.php`
+
+The current factory validator-construction block ends with `debug: filter_var(...)`. `AccordFactory` is in namespace `Fissible\Accord`, so `RuntimeOptions` needs NO `use`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/Unit/AccordFactoryTest.php` (which, from #8 Task references and #9, imports `RecordingLogger`, `Response`, `ServerRequest`, `RequestHandlerInterface`, etc., and has a `passthroughHandler()` helper), add these two tests. If `passthroughHandler()` is NOT present, also add it (see #9's AccordFactoryTest for its exact form: a private method returning an anonymous `RequestHandlerInterface` whose `handle()` returns `new Response(200)`).
+
+```php
+    public function test_factory_exclude_skips_validation(): void
+    {
+        $logger = new RecordingLogger();
+
+        $middleware = AccordFactory::make(
+            ['exclude' => ['/v99/x'], 'debug' => true, 'logger' => $logger],
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        $middleware->process(new ServerRequest('GET', '/v99/x'), $this->passthroughHandler());
+
+        $reasons = array_column(array_column($logger->records, 'context'), 'reason');
+        $this->assertContains('excluded', $reasons);
+    }
+
+    public function test_factory_string_false_validate_responses_disables_response_validation(): void
+    {
+        $logger = new RecordingLogger();
+
+        $middleware = AccordFactory::make(
+            ['validate_responses' => 'false', 'debug' => true, 'logger' => $logger], // string must parse to false
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        // /v99/x has no spec: request → missing_spec; response → response_validation_disabled
+        // (the response gate fires BEFORE spec load; if 'false' were mis-cast to true,
+        //  the response side would log missing_spec instead).
+        $middleware->process(new ServerRequest('GET', '/v99/x'), $this->passthroughHandler());
+
+        $reasons = array_column(array_column($logger->records, 'context'), 'reason');
+        $this->assertContains('response_validation_disabled', $reasons);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter AccordFactoryTest`
+Expected: FAIL — the factory builds a default `RuntimeOptions`, so `exclude` is ignored (`excluded` never logged) and `validate_responses` has no effect.
+
+- [ ] **Step 3: Build RuntimeOptions in the factory**
+
+In `src/AccordFactory.php`, replace the `$validator = new ContractValidator(...)` call with (add the `runtimeOptions` arg after `debug:`):
+
+```php
+        $validator = new ContractValidator(
+            versionExtractor:    $versionExtractor,
+            specSource:          $specSource,
+            failureMode:         $requestMode,
+            failureCallable:     $failureCallable,
+            logger:              $logger,
+            responseFailureMode: $responseMode,
+            debug:               filter_var($config['debug'] ?? false, FILTER_VALIDATE_BOOLEAN),
+            runtimeOptions:      new RuntimeOptions(
+                excludedPaths:      $config['exclude'] ?? [],
+                validateResponses:  filter_var($config['validate_responses'] ?? true, FILTER_VALIDATE_BOOLEAN),
+                responseSampleRate: (float) ($config['response_sample_rate'] ?? 1.0),
+            ),
+        );
+```
+
+Then update the class docblock's "Config keys (all optional)" list to add:
+
+```php
+ *   exclude          — string[] of glob patterns; matched routes skip all validation (default: [])
+ *   validate_responses — bool; validate responses (requests always validated)  (default: true)
+ *   response_sample_rate — float 0.0–1.0; fraction of responses to validate, clamped (default: 1.0)
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS. 135 prior + 2 = 137 tests. Deprecations 5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/AccordFactory.php tests/Unit/AccordFactoryTest.php
+git commit -m "feat: AccordFactory builds RuntimeOptions from config (#8)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: README — running it safely in production
+
+**Files:**
+- Modify: `README.md`
+
+No test (docs).
+
+- [ ] **Step 1: Add config lines**
+
+In `README.md`, find the Laravel published-config snippet (it contains `'debug' => env('ACCORD_DEBUG', false), ...` added in #9). Add, after the `debug` line:
+
+```php
+    'exclude'              => [],                                  // glob patterns; matched routes skip all validation
+    'validate_responses'   => env('ACCORD_VALIDATE_RESPONSES', true),    // false = don't validate responses (requests still validated)
+    'response_sample_rate' => env('ACCORD_RESPONSE_SAMPLE_RATE', 1.0),   // fraction of responses to validate (0.0–1.0)
+```
+
+- [ ] **Step 2: Add the production section**
+
+Immediately after that config snippet's closing ``` fence, insert:
+
+```markdown
+**Running it in production — controlling overhead.** Response validation runs on every
+response by default. Three knobs let you keep it cheap:
+
+- **`exclude`** — glob patterns (`*` matches any characters, including `/`). Matched routes
+  skip *all* validation, request and response (e.g. `['/v2/health', '/v2/internal/*',
+  '*/metrics']`). Cost: those routes aren't contract-checked at all.
+- **`validate_responses => false`** — stop validating responses while still validating
+  requests. Cost: response drift goes uncaught at runtime — rely on the
+  `AssertsApiContracts` CI checks instead.
+- **`response_sample_rate`** — validate only a fraction of responses (e.g. `0.1` ≈ 10%).
+  Trades coverage for throughput on hot or large-payload endpoints; out-of-range values are
+  clamped to `0.0..1.0`.
+
+These show up in `ACCORD_DEBUG` output as `excluded`, `response_validation_disabled`, and
+`not_sampled` skips, and as `wasValidated() === false`. **Note:** with `validate_responses`
+off (or a very low sample rate) *and* `ACCORD_DEBUG` on, debug logs *every* response as a
+skip — that's expected for a diagnostic mode, but don't run that combination in steady
+state. (For the Slim/Mezzio `AccordFactory`, remember debug logging only produces output
+when you pass a `logger` config key — the Laravel driver injects one automatically.)
+```
+
+- [ ] **Step 3: Verify suite unaffected**
+
+Run: `vendor/bin/phpunit --colors=never` → 137 tests, 5 deprecations.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document runtime validation options + production adoption (#8)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Full suite + clean tree**
+
+```bash
+vendor/bin/phpunit --colors=never
+git diff --check
+```
+Expected: 137 tests pass, 5 deprecations (no new). `git diff --check` prints nothing.
+
+- [ ] **Step 2: Core stayed framework-agnostic**
+
+```bash
+grep -rn 'Illuminate\\' src/ | grep -v src/Drivers/
+```
+Expected: no output.
+
+- [ ] **Step 3: Push + PR (only if the user asks)**
+
+Do not push/PR unless asked. When asked:
+
+```bash
+git push -u origin feat/runtime-options
+gh pr create --title "feat: runtime validation options — exclusions, sampling, response toggle (#8)" --body "$(cat <<'EOF'
+Implements #8. Lets the runtime middleware run cheaply in production.
+
+- `RuntimeOptions` value object: glob route exclusions (`*` crosses `/`), response-validation toggle, response sampling (rate clamped 0.0–1.0; pure, injectable draw source).
+- `ContractValidator` applies them as EARLY skips (before spec load) → new `SkipReason`s `excluded` / `response_validation_disabled` / `not_sampled`. Middlewares unchanged (skips are `valid=true`); #9's `ACCORD_DEBUG` + `wasValidated()` report them for free.
+- Exclusions apply to request + response; toggle and sampling are response-only.
+- Laravel config (`exclude`, `validate_responses`, `response_sample_rate`) + provider wiring; `AccordFactory` builds RuntimeOptions (bool-safe + float-cast).
+- README "running it in production" section with per-knob cost + the debug-noise caveat.
+
+Backward compatible: permissive defaults reproduce current behavior; new ctor param trailing; new skip reasons additive.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** SkipReason +3 (T1), RuntimeOptions glob/toggle/sampling/clamp (T2), validator early gates + precedence + short-circuit-before-spec (T3), config knobs documented (T4), provider wiring (T5), factory bool-safe wiring (T6), README incl. debug-noise + factory-logger caveat (T7), framework-agnostic guard (T8). Exclusions-both-directions and response-only toggle/sampling are covered by T3 (`test_excluded_request/response`, `test_request_still_validated_when_responses_disabled`). The "first gate wins" semantics is exercised by `test_exclusion_takes_precedence_over_unversioned` and `test_exclusion_short_circuits_before_spec_load`.
+- **Type consistency:** `RuntimeOptions(excludedPaths, validateResponses, responseSampleRate, sampler)` used identically in T3/T5/T6; `isExcluded`/`validatesResponses`/`shouldSampleResponse` names consistent; `runtimeOptions` is the 8th ctor param everywhere (named-arg call sites); new `SkipReason` values (`excluded`/`response_validation_disabled`/`not_sampled`) consistent across T1/T3/T6/T7.
+- **No placeholders:** every code step shows full code; expected counts cumulative (114→137).
+- **Carried plan notes:** `exclude` read as a plain array (`config('accord.exclude', [])` / `$config['exclude'] ?? []`), no single-string coercion (YAGNI, spec says array); README keeps the #9 factory-logger caveat.

--- a/docs/superpowers/specs/2026-06-15-runtime-validation-options-design.md
+++ b/docs/superpowers/specs/2026-06-15-runtime-validation-options-design.md
@@ -1,0 +1,217 @@
+# Runtime validation options: exclusions, response sampling, response toggle (#8)
+
+**Date:** 2026-06-15
+**Issue:** #8 (route exclusions, response sampling, response-validation toggle)
+**Package state:** accord is at v1.2.0. This is additive and backward compatible.
+
+## Problem
+
+Runtime response validation applies to every schema-backed response, and there is no
+package-level way to exclude routes, sample responses, or turn off response validation
+while keeping request validation. Large paginated responses and high-volume endpoints pay
+avoidable overhead, which discourages turning the middleware on in production.
+
+## Decisions (confirmed with user)
+
+- **Knobs live in the validator as early skips**, via a new framework-agnostic
+  `RuntimeOptions` collaborator. Excluded / response-disabled / sampled-out become
+  first-class `SkipReason`s, so #9's `ACCORD_DEBUG` logging and `wasValidated()` report them
+  automatically and identically across Laravel/Slim/Mezzio. **The middlewares are unchanged**
+  (a skip is `valid=true`, so the existing `if (!$result->valid)` already passes traffic
+  through).
+- **Exclusions use path glob patterns** where `*` matches any characters **including `/`**
+  (so `/v2/internal/*` matches `/v2/internal/a/b/c`, and `*/metrics` matches any version).
+  No `**`; segment-bounded matching is intentionally out of scope (more surprising without
+  `**`).
+- **Gates run early — before spec load/parse/match** — because the entire point is to save
+  work. Consequence: skip reasons report **the first runtime gate that prevented
+  validation, not a full analysis of all other reasons validation might later have
+  skipped**. (E.g. with response validation disabled, every response reports
+  `response_validation_disabled` even if it also had no matching schema.)
+- **Exclusions apply to both directions** (request and response). **Toggle and sampling are
+  response-only** (responses are the expensive, large-payload side).
+
+## Architecture
+
+The core (`src/` excluding `src/Drivers/`) stays framework-agnostic.
+
+### Components (dependency order, leaves → roots)
+
+1. **`SkipReason` — three new cases** (additive; nothing does an exhaustive `match` on it):
+   ```php
+   case Excluded                   = 'excluded';
+   case ResponseValidationDisabled = 'response_validation_disabled';
+   case NotSampled                 = 'not_sampled';
+   ```
+
+2. **`RuntimeOptions` (core, new value object)** — holds the policy with permissive defaults
+   (= current behavior). A single, focused, testable unit:
+   ```php
+   final class RuntimeOptions
+   {
+       private readonly float $responseSampleRate; // clamped to [0.0, 1.0]
+       /** @var \Closure(): float */
+       private readonly \Closure $sampler;
+
+       /** @param string[] $excludedPaths glob patterns */
+       public function __construct(
+           private readonly array $excludedPaths = [],
+           private readonly bool $validateResponses = true,
+           float $responseSampleRate = 1.0,
+           ?\Closure $sampler = null,
+       ) {
+           // Range policy: clamp, never throw — a typo'd 2 becomes 1.0, -1 becomes 0.0.
+           $this->responseSampleRate = max(0.0, min(1.0, $responseSampleRate));
+           // Default draw source; injectable for deterministic tests. Returns a float in [0,1].
+           $this->sampler = $sampler ?? static fn (): float => mt_rand() / mt_getrandmax();
+       }
+
+       public function isExcluded(string $path): bool
+       {
+           foreach ($this->excludedPaths as $pattern) {
+               $regex = '#^' . str_replace('\*', '.*', preg_quote($pattern, '#')) . '$#';
+               if (preg_match($regex, $path) === 1) {
+                   return true;
+               }
+           }
+           return false;
+       }
+
+       public function validatesResponses(): bool
+       {
+           return $this->validateResponses;
+       }
+
+       public function shouldSampleResponse(): bool
+       {
+           if ($this->responseSampleRate >= 1.0) {
+               return true;   // always validate (no draw; avoids the 1.0 < 1.0 edge)
+           }
+           if ($this->responseSampleRate <= 0.0) {
+               return false;  // never validate
+           }
+           return ($this->sampler)() < $this->responseSampleRate;
+       }
+   }
+   ```
+   - **Sampler is a pure draw source** returning a float in `[0,1]`. `shouldSampleResponse()`
+     is then pure given the (clamped) rate and the draw: inject `fn () => 0.3` against rate
+     `0.5` → `true`; `fn () => 0.7` → `false`. The sampler is a **test seam only** — not
+     user-configurable from config.
+   - **Rate clamping** happens once at construction; `shouldSampleResponse()` never sees an
+     out-of-range value.
+
+3. **`ContractValidator` — early gates.** New **trailing** constructor param, placed AFTER
+   #9's `bool $debug` (keep it last to avoid ABI churn):
+   ```php
+   public function __construct(
+       private readonly VersionExtractor $versionExtractor,
+       private readonly SpecSourceInterface $specSource,
+       private readonly FailureMode $failureMode = FailureMode::Exception,
+       private readonly mixed $failureCallable = null,
+       private readonly LoggerInterface $logger = new NullLogger(),
+       private readonly ?FailureMode $responseFailureMode = null,
+       private readonly bool $debug = false,
+       private readonly RuntimeOptions $runtimeOptions = new RuntimeOptions(),
+   ) {}
+   ```
+   - `validateRequest`: extract `$version` and `$path` up front, then
+     **`if ($this->runtimeOptions->isExcluded($path)) return $this->skip(SkipReason::Excluded,
+     $version ?? 'unversioned', $request, Direction::Request);`** — before the spec is loaded.
+     Then the existing flow unchanged.
+   - `validateResponse`: extract `$version` and `$path` up front, then in this order, all
+     before spec load:
+     1. `isExcluded($path)` → `skip(Excluded, …, Direction::Response)`
+     2. `!validatesResponses()` → `skip(ResponseValidationDisabled, …, Direction::Response)`
+     3. `!shouldSampleResponse()` → `skip(NotSampled, …, Direction::Response)`
+     Then the existing flow unchanged.
+   - The `$version ?? 'unversioned'` fallback is used for the gate skips because exclusion can
+     match unversioned paths (e.g. `/health`).
+
+4. **Laravel config `accord.php`** — three keys, each documented with purpose **and** cost
+   (knob convention):
+   - `'exclude' => []` — array of glob patterns; matched routes skip validation entirely
+     (both directions). Cost: those routes are *not* contract-checked at all.
+   - `'validate_responses' => env('ACCORD_VALIDATE_RESPONSES', true)` — when false, responses
+     are not validated (requests still are). Cost: response drift goes uncaught at runtime.
+   - `'response_sample_rate' => env('ACCORD_RESPONSE_SAMPLE_RATE', 1.0)` — fraction `0.0–1.0`
+     of responses to validate; trades coverage for throughput on hot/large endpoints.
+     Out-of-range values are clamped (`2 → 1.0`, `-1 → 0.0`).
+
+5. **`AccordServiceProvider`** — build a `RuntimeOptions` from the three config values and
+   pass it via the `runtimeOptions:` named arg. `validate_responses` via `(bool)`,
+   `response_sample_rate` via `(float)`, `exclude` as the array (default `[]`).
+
+6. **`AccordFactory`** (Slim/Mezzio, plain array config) — same three keys; build
+   `RuntimeOptions` with `validate_responses` via `filter_var(... FILTER_VALIDATE_BOOLEAN)`
+   (string-safe, like `debug`), `response_sample_rate` via `(float)`, `exclude` as array.
+   Docblock updated to list the three keys.
+
+7. **README** — a "Running it safely in production" section: exclude health/metrics/internal
+   routes, sample responses on hot endpoints, or disable response validation — each with the
+   *why/cost*. **Explicit warning:** with `validate_responses=false` (or a very low sample
+   rate) AND `ACCORD_DEBUG=true`, debug logs every response as a skip
+   (`response_validation_disabled` / `not_sampled`) — that's expected, since debug is a
+   diagnostic mode, but it is noisy; don't run that combination in steady state.
+
+## Data flow (Laravel; `/v2/health` excluded, debug on)
+
+```
+GET /v2/health
+  → validateRequest → isExcluded('/v2/health') → skip(Excluded, request)
+       → ACCORD_DEBUG logs {direction:request, reason:excluded}
+       → valid=true → middleware passes request through (no spec loaded)
+  → $next → controller → response
+  → validateResponse → isExcluded('/v2/health') → skip(Excluded, response)
+       → logs {direction:response, reason:excluded}
+       → valid=true → original response returned unvalidated
+```
+
+## Error handling / backward compatibility
+
+- Gate skips are `valid=true`; both middlewares (`if (!$result->valid)`) behave exactly as
+  today — excluded/disabled/sampled-out traffic passes through unvalidated, nothing throws.
+- `RuntimeOptions` defaults are permissive (`[]`, `true`, `1.0`) → identical behavior for
+  any existing caller that doesn't pass it.
+- New `SkipReason` cases are additive; the trailing `ContractValidator` ctor param is
+  optional with a `new RuntimeOptions()` default. No public signature breaks.
+
+## Testing (TDD, one behavior per test)
+
+`RuntimeOptions` (unit):
+- `isExcluded`: exact match; `*` crosses `/` (`/v2/internal/*` matches `/v2/internal/a/b`);
+  `*/metrics` matches `/v9/metrics`; non-match returns false; empty list → false.
+- rate clamping: `2.0 → 1.0` (always), `-1.0 → 0.0` (never).
+- `shouldSampleResponse`: rate `1.0` → true without consulting sampler; rate `0.0` → false;
+  rate `0.5` with injected draw `0.3` → true, draw `0.7` → false.
+- `validatesResponses` reflects the flag.
+
+`ContractValidator` (feature, against the v2 fixture):
+- excluded request → `skip(Excluded)`, `wasValidated()===false`.
+- excluded response → `skip(Excluded)`.
+- `validateResponses=false` → response → `ResponseValidationDisabled` (and a normally-valid
+  response is NOT validated).
+- sample rate with injected draw above the rate → `NotSampled`; draw below → normal
+  validation occurs (genuine pass/fail).
+- exclusion precedence: an excluded path that is also unversioned → `Excluded` (not
+  `Unversioned`).
+- gates short-circuit before spec load: an excluded request to a version whose spec file is
+  absent still returns `Excluded` (not `MissingSpec`).
+- debug on: an excluded skip logs `reason: excluded` with the right direction.
+
+Laravel driver / factory:
+- Provider builds `RuntimeOptions` from config (resolve validator; exclude a path; assert the
+  result is `Excluded`).
+- `AccordFactory` with `'validate_responses' => 'false'` (string) disables response validation
+  (FILTER_VALIDATE_BOOLEAN); with `'exclude' => [...]` excludes; with `response_sample_rate`
+  cast to float.
+
+Whole suite stays green (currently 114) with no new deprecations.
+
+## Out of scope (YAGNI)
+
+- Request sampling (responses are the expensive side).
+- Per-route or per-direction sample rates / per-direction exclusions.
+- `**` segment-aware globs or regex exclusions.
+- User-configurable sampler (the closure is a test seam only).
+- Strict enforcement interactions (separate concern).

--- a/src/AccordFactory.php
+++ b/src/AccordFactory.php
@@ -27,6 +27,9 @@ use Psr\Log\NullLogger;
  *                      Requires a logger to produce output (see below) (default: false)
  *   logger           — Psr\Log\LoggerInterface|null; where debug skip logs are written;
  *                      without it, debug logging has nowhere to go    (default: NullLogger)
+ *   exclude          — string[] of glob patterns; matched routes skip all validation (default: [])
+ *   validate_responses — bool; validate responses (requests always validated)  (default: true)
+ *   response_sample_rate — float 0.0–1.0; fraction of responses to validate, clamped (default: 1.0)
  */
 final class AccordFactory
 {
@@ -53,6 +56,11 @@ final class AccordFactory
             logger:              $logger,
             responseFailureMode: $responseMode,
             debug:               filter_var($config['debug'] ?? false, FILTER_VALIDATE_BOOLEAN),
+            runtimeOptions:      new RuntimeOptions(
+                excludedPaths:      $config['exclude'] ?? [],
+                validateResponses:  filter_var($config['validate_responses'] ?? true, FILTER_VALIDATE_BOOLEAN),
+                responseSampleRate: (float) ($config['response_sample_rate'] ?? 1.0),
+            ),
         );
 
         return new AccordMiddleware($validator);

--- a/src/ContractValidator.php
+++ b/src/ContractValidator.php
@@ -30,11 +30,17 @@ class ContractValidator
         private readonly LoggerInterface $logger = new NullLogger(),
         private readonly ?FailureMode $responseFailureMode = null,
         private readonly bool $debug = false,
+        private readonly RuntimeOptions $runtimeOptions = new RuntimeOptions(),
     ) {}
 
     public function validateRequest(ServerRequestInterface $request): ValidationResult
     {
         $version = $this->versionExtractor->extract($request);
+        $path    = $request->getUri()->getPath();
+
+        if ($this->runtimeOptions->isExcluded($path)) {
+            return $this->skip(SkipReason::Excluded, $version ?? 'unversioned', $request, Direction::Request);
+        }
 
         if ($version === null) {
             return $this->skip(SkipReason::Unversioned, 'unversioned', $request, Direction::Request);
@@ -47,7 +53,6 @@ class ContractValidator
         }
 
         $method = strtolower($request->getMethod());
-        $path   = $request->getUri()->getPath();
         $match  = $this->findPathItem($spec, $path);
 
         if ($match === null) {
@@ -100,7 +105,21 @@ class ContractValidator
 
     public function validateResponse(ResponseInterface $response, ServerRequestInterface $request): ValidationResult
     {
-        $version = $this->versionExtractor->extract($request);
+        $version  = $this->versionExtractor->extract($request);
+        $path     = $request->getUri()->getPath();
+        $fallback = $version ?? 'unversioned';
+
+        if ($this->runtimeOptions->isExcluded($path)) {
+            return $this->skip(SkipReason::Excluded, $fallback, $request, Direction::Response);
+        }
+
+        if (!$this->runtimeOptions->validatesResponses()) {
+            return $this->skip(SkipReason::ResponseValidationDisabled, $fallback, $request, Direction::Response);
+        }
+
+        if (!$this->runtimeOptions->shouldSampleResponse()) {
+            return $this->skip(SkipReason::NotSampled, $fallback, $request, Direction::Response);
+        }
 
         if ($version === null) {
             return $this->skip(SkipReason::Unversioned, 'unversioned', $request, Direction::Response);
@@ -113,7 +132,6 @@ class ContractValidator
         }
 
         $method    = strtolower($request->getMethod());
-        $path      = $request->getUri()->getPath();
         $operation = $this->findOperation($spec, $method, $path);
 
         if ($operation === null) {

--- a/src/Drivers/Laravel/Providers/AccordServiceProvider.php
+++ b/src/Drivers/Laravel/Providers/AccordServiceProvider.php
@@ -8,6 +8,7 @@ use Fissible\Accord\AccordMiddleware;
 use Fissible\Accord\ContractValidator;
 use Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract;
 use Fissible\Accord\FailureMode;
+use Fissible\Accord\RuntimeOptions;
 use Fissible\Accord\FileSpecSource;
 use Fissible\Accord\SpecSourceInterface;
 use Fissible\Accord\UrlSpecSource;
@@ -58,6 +59,11 @@ class AccordServiceProvider extends ServiceProvider
                 logger:              $this->resolveLogger(),
                 responseFailureMode: $responseMode,
                 debug:               (bool) config('accord.debug', false),
+                runtimeOptions:      new RuntimeOptions(
+                    excludedPaths:      config('accord.exclude', []),
+                    validateResponses:  (bool) config('accord.validate_responses', true),
+                    responseSampleRate: (float) config('accord.response_sample_rate', 1.0),
+                ),
             );
         });
 

--- a/src/Drivers/Laravel/config/accord.php
+++ b/src/Drivers/Laravel/config/accord.php
@@ -103,4 +103,41 @@ return [
     |
     */
     'debug' => (bool) env('ACCORD_DEBUG', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Route Exclusions
+    |--------------------------------------------------------------------------
+    | Glob patterns matched against the request URI path; '*' matches any
+    | characters, INCLUDING '/'. Matched routes skip BOTH request and response
+    | validation entirely — they are not contract-checked at all. Use only for
+    | routes you deliberately don't cover (health checks, metrics, internal
+    | endpoints), e.g. ['/v2/health', '/v2/internal/*', '/api/metrics'].
+    |
+    */
+    'exclude' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validate Responses
+    |--------------------------------------------------------------------------
+    | When false, responses are not validated at runtime but requests still are.
+    | Cost: response/contract drift goes uncaught at runtime — rely on CI
+    | (AssertsApiContracts) to catch it instead. Useful for high-volume APIs
+    | where response validation overhead isn't worth it in production.
+    |
+    */
+    'validate_responses' => env('ACCORD_VALIDATE_RESPONSES', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Response Sample Rate
+    |--------------------------------------------------------------------------
+    | Fraction (0.0–1.0) of responses to validate; the rest pass through
+    | unchecked. Trades response coverage for throughput on hot or large-payload
+    | endpoints. Out-of-range values are clamped (2 -> 1.0, -1 -> 0.0). 1.0
+    | validates every response (default).
+    |
+    */
+    'response_sample_rate' => env('ACCORD_RESPONSE_SAMPLE_RATE', 1.0),
 ];

--- a/src/Drivers/Laravel/config/accord.php
+++ b/src/Drivers/Laravel/config/accord.php
@@ -96,8 +96,9 @@ return [
     |--------------------------------------------------------------------------
     | When true, Accord logs (at "debug" level) every request and response it
     | SKIPPED instead of validated, with the reason — unversioned, missing_spec,
-    | unmatched_operation, missing_request_schema, missing_response_schema, or
-    | unsupported_media_type. Use it to answer "is my API actually being
+    | unmatched_operation, missing_request_schema, missing_response_schema,
+    | unsupported_media_type, excluded, response_validation_disabled, or
+    | not_sampled. Use it to answer "is my API actually being
     | validated, and if not, why?". Off by default and zero overhead when off;
     | leave it off in production unless you are diagnosing silent non-validation.
     |

--- a/src/RuntimeOptions.php
+++ b/src/RuntimeOptions.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord;
+
+use Closure;
+
+/**
+ * Runtime validation policy: which routes to skip, whether to validate responses,
+ * and what fraction of responses to sample. Permissive defaults reproduce
+ * "validate everything" behavior.
+ */
+final class RuntimeOptions
+{
+    private readonly float $responseSampleRate;
+
+    /** @var Closure(): float */
+    private readonly Closure $sampler;
+
+    /**
+     * @param string[]      $excludedPaths      glob patterns; '*' matches any chars including '/'
+     * @param bool          $validateResponses  validate responses (requests are always validated unless excluded)
+     * @param float         $responseSampleRate fraction 0.0–1.0 of responses to validate (clamped, never throws)
+     * @param Closure(): float|null $sampler    test seam: a draw source returning a float in [0,1]
+     */
+    public function __construct(
+        private readonly array $excludedPaths = [],
+        private readonly bool $validateResponses = true,
+        float $responseSampleRate = 1.0,
+        ?Closure $sampler = null,
+    ) {
+        $this->responseSampleRate = max(0.0, min(1.0, $responseSampleRate));
+        $this->sampler            = $sampler ?? static fn (): float => mt_rand() / mt_getrandmax();
+    }
+
+    public function isExcluded(string $path): bool
+    {
+        foreach ($this->excludedPaths as $pattern) {
+            $regex = '#^' . str_replace('\*', '.*', preg_quote($pattern, '#')) . '$#';
+
+            if (preg_match($regex, $path) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function validatesResponses(): bool
+    {
+        return $this->validateResponses;
+    }
+
+    public function shouldSampleResponse(): bool
+    {
+        if ($this->responseSampleRate >= 1.0) {
+            return true;
+        }
+
+        if ($this->responseSampleRate <= 0.0) {
+            return false;
+        }
+
+        return ($this->sampler)() < $this->responseSampleRate;
+    }
+}

--- a/src/SkipReason.php
+++ b/src/SkipReason.php
@@ -6,10 +6,13 @@ namespace Fissible\Accord;
 
 enum SkipReason: string
 {
-    case Unversioned           = 'unversioned';
-    case MissingSpec           = 'missing_spec';
-    case UnmatchedOperation    = 'unmatched_operation';
-    case MissingRequestSchema  = 'missing_request_schema';
-    case MissingResponseSchema = 'missing_response_schema';
-    case UnsupportedMediaType  = 'unsupported_media_type';
+    case Unversioned                = 'unversioned';
+    case MissingSpec                = 'missing_spec';
+    case UnmatchedOperation         = 'unmatched_operation';
+    case MissingRequestSchema       = 'missing_request_schema';
+    case MissingResponseSchema      = 'missing_response_schema';
+    case UnsupportedMediaType       = 'unsupported_media_type';
+    case Excluded                   = 'excluded';
+    case ResponseValidationDisabled = 'response_validation_disabled';
+    case NotSampled                 = 'not_sampled';
 }

--- a/tests/Feature/ContractValidatorTest.php
+++ b/tests/Feature/ContractValidatorTest.php
@@ -9,6 +9,7 @@ use Fissible\Accord\Direction;
 use Fissible\Accord\Exception\ContractViolationException;
 use Fissible\Accord\FailureMode;
 use Fissible\Accord\FileSpecSource;
+use Fissible\Accord\RuntimeOptions;
 use Fissible\Accord\Tests\Support\RecordingLogger;
 use Fissible\Accord\ValidationResult;
 use Fissible\Accord\SkipReason;
@@ -584,5 +585,122 @@ class ContractValidatorTest extends TestCase
         $validator->validateRequest(new ServerRequest('GET', '/v99/items'));
 
         $this->assertCount(0, $logger->records);
+    }
+
+    private function makeOptionsValidator(
+        RuntimeOptions $options,
+        ?RecordingLogger $logger = null,
+        bool $debug = false,
+    ): ContractValidator {
+        return new ContractValidator(
+            versionExtractor: $this->versionExtractor,
+            specSource:       new FileSpecSource($this->fixturesPath, '{base}/{version}'),
+            logger:           $logger ?? new RecordingLogger(),
+            debug:            $debug,
+            runtimeOptions:   $options,
+        );
+    }
+
+    // --- runtime options: exclusions / toggle / sampling (#8) ---
+
+    public function test_excluded_request_is_skipped(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/v2/items']));
+
+        $result = $validator->validateRequest(new ServerRequest('GET', '/v2/items'));
+
+        $this->assertSame(SkipReason::Excluded, $result->skipReason);
+        $this->assertFalse($result->wasValidated());
+    }
+
+    public function test_excluded_response_is_skipped(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/v2/items']));
+
+        $result = $validator->validateResponse(
+            $this->jsonResponse(200, '[]'),
+            new ServerRequest('GET', '/v2/items'),
+        );
+
+        $this->assertSame(SkipReason::Excluded, $result->skipReason);
+    }
+
+    public function test_exclusion_takes_precedence_over_unversioned(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/health']));
+
+        $result = $validator->validateRequest(new ServerRequest('GET', '/health'));
+
+        $this->assertSame(SkipReason::Excluded, $result->skipReason);
+    }
+
+    public function test_exclusion_short_circuits_before_spec_load(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/v99/*']));
+
+        $result = $validator->validateRequest(new ServerRequest('GET', '/v99/items'));
+
+        $this->assertSame(SkipReason::Excluded, $result->skipReason);
+    }
+
+    public function test_response_validation_disabled_skips_response(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(validateResponses: false));
+
+        $result = $validator->validateResponse(
+            $this->jsonResponse(200, '[]'),
+            new ServerRequest('GET', '/v2/items'),
+        );
+
+        $this->assertSame(SkipReason::ResponseValidationDisabled, $result->skipReason);
+    }
+
+    public function test_request_still_validated_when_responses_disabled(): void
+    {
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(validateResponses: false));
+
+        $result = $validator->validateRequest(new ServerRequest('GET', '/v2/items/5'));
+
+        $this->assertTrue($result->wasValidated());
+    }
+
+    public function test_response_sampled_out_is_skipped(): void
+    {
+        $validator = $this->makeOptionsValidator(
+            new RuntimeOptions(responseSampleRate: 0.5, sampler: fn (): float => 0.7),
+        );
+
+        $result = $validator->validateResponse(
+            $this->jsonResponse(200, '[]'),
+            new ServerRequest('GET', '/v2/items'),
+        );
+
+        $this->assertSame(SkipReason::NotSampled, $result->skipReason);
+    }
+
+    public function test_response_sampled_in_is_validated(): void
+    {
+        $validator = $this->makeOptionsValidator(
+            new RuntimeOptions(responseSampleRate: 0.5, sampler: fn (): float => 0.3),
+        );
+
+        $result = $validator->validateResponse(
+            $this->jsonResponse(200, '[]'),
+            new ServerRequest('GET', '/v2/items'),
+        );
+
+        $this->assertTrue($result->wasValidated());
+        $this->assertTrue($result->valid);
+    }
+
+    public function test_debug_logs_excluded_skip(): void
+    {
+        $logger    = new RecordingLogger();
+        $validator = $this->makeOptionsValidator(new RuntimeOptions(['/v2/items']), $logger, debug: true);
+
+        $validator->validateRequest(new ServerRequest('GET', '/v2/items'));
+
+        $this->assertSame('excluded', $logger->records[0]['context']['reason']);
+        $this->assertSame('request', $logger->records[0]['context']['direction']);
     }
 }

--- a/tests/Feature/LaravelServiceProviderTest.php
+++ b/tests/Feature/LaravelServiceProviderTest.php
@@ -72,6 +72,9 @@ namespace Fissible\Accord\Tests\Feature {
                 'accord.log_channel'              => null,
                 'accord.request_violation_status' => 422,
                 'accord.debug'             => false,
+                'accord.exclude'               => [],
+                'accord.validate_responses'    => true,
+                'accord.response_sample_rate'  => 1.0,
             ];
         }
 
@@ -181,6 +184,19 @@ namespace Fissible\Accord\Tests\Feature {
             $this->assertNotEmpty($logger->records);
             $this->assertSame('debug', $logger->records[0]['level']);
             $this->assertSame('missing_spec', $logger->records[0]['context']['reason']);
+        }
+
+        public function test_exclude_config_skips_validation(): void
+        {
+            LaravelConfig::$values['accord.exclude'] = ['/v99/x'];
+
+            $app = new FakeLaravelContainer([LoggerInterface::class => new RecordingLogger()]);
+            (new AccordServiceProvider($app))->register();
+
+            $validator = $app->make(ContractValidator::class);
+            $result    = $validator->validateRequest(new ServerRequest('GET', '/v99/x'));
+
+            $this->assertSame(\Fissible\Accord\SkipReason::Excluded, $result->skipReason);
         }
 
         private function readStatus(ValidateApiContract $middleware): int

--- a/tests/Unit/AccordFactoryTest.php
+++ b/tests/Unit/AccordFactoryTest.php
@@ -132,4 +132,37 @@ class AccordFactoryTest extends TestCase
 
         $this->assertCount(0, $logger->records);
     }
+
+    public function test_factory_exclude_skips_validation(): void
+    {
+        $logger = new RecordingLogger();
+
+        $middleware = AccordFactory::make(
+            ['exclude' => ['/v99/x'], 'debug' => true, 'logger' => $logger],
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        $middleware->process(new ServerRequest('GET', '/v99/x'), $this->passthroughHandler());
+
+        $reasons = array_column(array_column($logger->records, 'context'), 'reason');
+        $this->assertContains('excluded', $reasons);
+    }
+
+    public function test_factory_string_false_validate_responses_disables_response_validation(): void
+    {
+        $logger = new RecordingLogger();
+
+        $middleware = AccordFactory::make(
+            ['validate_responses' => 'false', 'debug' => true, 'logger' => $logger], // string must parse to false
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        // /v99/x has no spec: request → missing_spec; response → response_validation_disabled
+        // (the response gate fires BEFORE spec load; if 'false' were mis-cast to true,
+        //  the response side would log missing_spec instead).
+        $middleware->process(new ServerRequest('GET', '/v99/x'), $this->passthroughHandler());
+
+        $reasons = array_column(array_column($logger->records, 'context'), 'reason');
+        $this->assertContains('response_validation_disabled', $reasons);
+    }
 }

--- a/tests/Unit/RuntimeOptionsTest.php
+++ b/tests/Unit/RuntimeOptionsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Unit;
+
+use Fissible\Accord\RuntimeOptions;
+use PHPUnit\Framework\TestCase;
+
+class RuntimeOptionsTest extends TestCase
+{
+    public function test_exact_path_is_excluded(): void
+    {
+        $this->assertTrue((new RuntimeOptions(['/v2/health']))->isExcluded('/v2/health'));
+    }
+
+    public function test_non_matching_path_is_not_excluded(): void
+    {
+        $this->assertFalse((new RuntimeOptions(['/v2/health']))->isExcluded('/v2/users'));
+    }
+
+    public function test_empty_exclusions_never_match(): void
+    {
+        $this->assertFalse((new RuntimeOptions())->isExcluded('/v2/anything'));
+    }
+
+    public function test_star_matches_across_slashes(): void
+    {
+        $options = new RuntimeOptions(['/v2/internal/*']);
+
+        $this->assertTrue($options->isExcluded('/v2/internal/a/b/c'));
+        $this->assertFalse($options->isExcluded('/v2/public/x'));
+    }
+
+    public function test_leading_star_matches_any_version(): void
+    {
+        $this->assertTrue((new RuntimeOptions(['*/metrics']))->isExcluded('/v9/metrics'));
+    }
+
+    public function test_validates_responses_reflects_flag(): void
+    {
+        $this->assertTrue((new RuntimeOptions(validateResponses: true))->validatesResponses());
+        $this->assertFalse((new RuntimeOptions(validateResponses: false))->validatesResponses());
+    }
+
+    public function test_rate_above_one_is_clamped_to_always_sample(): void
+    {
+        $options = new RuntimeOptions(
+            responseSampleRate: 2.0,
+            sampler: fn (): float => throw new \RuntimeException('sampler must not be consulted at rate 1.0'),
+        );
+
+        $this->assertTrue($options->shouldSampleResponse());
+    }
+
+    public function test_rate_below_zero_is_clamped_to_never_sample(): void
+    {
+        $options = new RuntimeOptions(
+            responseSampleRate: -1.0,
+            sampler: fn (): float => throw new \RuntimeException('sampler must not be consulted at rate 0.0'),
+        );
+
+        $this->assertFalse($options->shouldSampleResponse());
+    }
+
+    public function test_draw_below_rate_is_sampled_in(): void
+    {
+        $options = new RuntimeOptions(responseSampleRate: 0.5, sampler: fn (): float => 0.3);
+
+        $this->assertTrue($options->shouldSampleResponse());
+    }
+
+    public function test_draw_at_or_above_rate_is_sampled_out(): void
+    {
+        $options = new RuntimeOptions(responseSampleRate: 0.5, sampler: fn (): float => 0.7);
+
+        $this->assertFalse($options->shouldSampleResponse());
+    }
+}

--- a/tests/Unit/SkipReasonTest.php
+++ b/tests/Unit/SkipReasonTest.php
@@ -18,4 +18,11 @@ class SkipReasonTest extends TestCase
         $this->assertSame('missing_response_schema', SkipReason::MissingResponseSchema->value);
         $this->assertSame('unsupported_media_type', SkipReason::UnsupportedMediaType->value);
     }
+
+    public function test_runtime_gate_backing_values(): void
+    {
+        $this->assertSame('excluded', SkipReason::Excluded->value);
+        $this->assertSame('response_validation_disabled', SkipReason::ResponseValidationDisabled->value);
+        $this->assertSame('not_sampled', SkipReason::NotSampled->value);
+    }
 }


### PR DESCRIPTION
Implements #8 (closes #8). Lets Accord's runtime middleware run cheaply in production.

## Summary

- **`RuntimeOptions`** value object: glob route **exclusions** (`*` matches any chars including `/`), a response-validation **toggle**, and response **sampling** (rate clamped to `0.0–1.0`; pure, injectable draw source for deterministic tests).
- **`ContractValidator` applies them as early skips — before spec load** — so excluded/disabled/sampled-out traffic pays no parse/match cost. New `SkipReason`s: `excluded`, `response_validation_disabled`, `not_sampled`. Because a skip is `valid=true`, **both middlewares are unchanged**, and #9's `ACCORD_DEBUG` logging + `wasValidated()` report these for free.
- Exclusions apply to **request + response** and take precedence over everything; **toggle and sampling are response-only** (the expensive, large-payload side).
- Laravel config (`exclude` / `validate_responses` / `response_sample_rate`), each documented with its cost, + provider wiring; `AccordFactory` builds `RuntimeOptions` (string-safe `validate_responses` via `FILTER_VALIDATE_BOOLEAN`, float rate, plain-array `exclude`).
- README "running it in production" section (per-knob cost + the debug-noise and Slim/Mezzio factory-logger caveats).

## Backward compatibility

Fully preserved: permissive defaults (`[]`, `true`, `1.0`) reproduce pre-#8 behavior exactly; the new `RuntimeOptions` ctor param is trailing (after #9's `debug`); new skip reasons are additive; middlewares and `valid()`/`invalid()` semantics unchanged.

## Test Plan

- [x] `vendor/bin/phpunit` — **137 tests pass** (was 114), 5 pre-existing cebe deprecations, none new
- [x] `git diff --check` clean
- [x] No `Illuminate\` outside `src/Drivers/` (core stays framework-agnostic)
- [x] Gate ordering (Excluded → ResponseValidationDisabled → NotSampled), exclusion precedence, and before-spec-load short-circuit all test-covered
- [x] `RuntimeOptions` glob/clamp/sampling unit-tested; sampler is a deterministic test seam

Design spec + implementation plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)