### PR TITLE
feat: persistent cache for file-backed specs (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,35 @@ return [
     'version_pattern'  => '/^\/v(\d+)(?:\/|$)/',
     'spec_source'    => env('ACCORD_SPEC_SOURCE', 'file'),       // file | url
     'spec_pattern'   => env('ACCORD_SPEC_PATTERN', '{base}/resources/openapi/{version}'),
+    'spec_cache'     => env('ACCORD_SPEC_CACHE', null),         // null|true|'store' — persist the parsed spec
     'spec_cache_ttl' => env('ACCORD_SPEC_CACHE_TTL', 3600),
 ];
 ```
+
+**Caching the spec.** `FileSpecSource` parses the OpenAPI file on every `load()`, and in
+PHP-FPM each request is a fresh process — so the (slow) YAML parse runs per request. Enable
+a persistent cache to parse once and rehydrate from cached JSON on subsequent requests
+(roughly an order of magnitude faster):
+
+- **`spec_cache`** — `null`/`false` = off (in-process cache only; the default), `true` = the
+  application's default cache store, or a store name (e.g. `'redis'`). The resolved cache is
+  wired into both file and URL sources.
+- **Invalidation is automatic for files:** the cache key includes the spec file's
+  modification time, so a redeployed/edited spec produces a new key and is re-parsed — no
+  `cache:clear` needed. `spec_cache_ttl` is just a backstop that evicts stale old-mtime
+  entries.
+
+Two caveats:
+
+- **Long-lived workers (Octane/RoadRunner):** `ContractValidator` keeps an in-process parsed
+  spec per version for the life of the worker, so mtime invalidation only helps fresh
+  processes (PHP-FPM). Restart workers on deploy (these stacks already do) to pick up a
+  changed spec.
+- **External `$ref`s:** the cache stores the spec's *serialized data*, so specs that rely on
+  **external-file** `$ref`s may not round-trip — keep specs self-contained. Internal
+  `#/components` refs are fine.
+
+For Slim/Mezzio, pass a PSR-16 cache instance directly: `AccordFactory::make(['spec_cache' => $psr16, ...], $basePath)`.
 
 **Running it in production — controlling overhead.** Response validation runs on every
 response by default. Three knobs let you keep it cheap:

--- a/docs/superpowers/plans/2026-06-16-file-spec-cache.md
+++ b/docs/superpowers/plans/2026-06-16-file-spec-cache.md
@@ -1,0 +1,856 @@
+# Persistent File Spec Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist the parsed OpenAPI spec across requests/processes via an optional PSR-16 cache on `FileSpecSource`, so PHP-FPM doesn't re-parse the YAML on every request.
+
+**Architecture:** `FileSpecSource` gains an optional PSR-16 cache (mirroring `UrlSpecSource`). On a miss it parses the file and stores `json_encode($spec->getSerializableData())`; on a hit it rehydrates via `Reader::readFromJson` (~15× faster than YAML). The key includes the file's `mtime`, so a redeployed spec auto-invalidates. The Laravel provider and `AccordFactory` resolve a cache and wire it into both file and URL sources (fixing the dead URL-cache wiring in the provider).
+
+**Tech Stack:** PHP 8.2+, PHPUnit 11, cebe/php-openapi, `psr/simple-cache` (already a dependency), illuminate/http (dev).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-file-spec-cache-design.md`
+
+**Branch:** `feat/file-spec-cache` (already checked out).
+
+**Conventions:** `declare(strict_types=1)` everywhere; no public non-readonly props; framework code only under `src/Drivers/`. Core classes are namespace `Fissible\Accord`. Run the suite with `vendor/bin/phpunit --colors=never`. **Baseline: 137 tests passing, 5 pre-existing cebe deprecations** — the count must stay 5.
+
+---
+
+## File Structure
+
+**Tests (create):** `tests/Support/ArrayCache.php` (in-memory PSR-16 double), `tests/Fixtures/v3.yaml` (internal-`$ref` fixture).
+
+**Core (modify):**
+- `src/FileSpecSource.php` — optional `?CacheInterface $cache` + `int $ttl`; mtime-keyed JSON round-trip.
+- `src/AccordFactory.php` — pass `spec_cache` + `spec_cache_ttl` to the `FileSpecSource` branch.
+
+**Laravel driver (modify):**
+- `src/Drivers/Laravel/config/accord.php` — `spec_cache` key; correct the `spec_cache_ttl` comment.
+- `src/Drivers/Laravel/Providers/AccordServiceProvider.php` — `resolveSpecCache()` + wire into both sources.
+
+**Tests (modify):** `tests/Unit/FileSpecSourceTest.php`, `tests/Feature/LaravelServiceProviderTest.php`, `tests/Unit/AccordFactoryTest.php`.
+
+**Docs (modify):** `README.md`.
+
+---
+
+## Task 1: `ArrayCache` test double
+
+**Files:**
+- Create: `tests/Support/ArrayCache.php`
+
+Test infrastructure (no behavior test). A minimal in-memory PSR-16 cache with a public `$store` so tests can inspect/overwrite entries. Declared as a plain `class` (not `final`) so a test can subclass it to simulate cache failures.
+
+- [ ] **Step 1: Create the double**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Support;
+
+use DateInterval;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Minimal in-memory PSR-16 cache for tests. The public $store array makes the
+ * cached entries inspectable/overwritable. Not for production use.
+ */
+class ArrayCache implements CacheInterface
+{
+    /** @var array<string, mixed> */
+    public array $store = [];
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->store[$key] ?? $default;
+    }
+
+    public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
+    {
+        $this->store[$key] = $value;
+
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        unset($this->store[$key]);
+
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        $this->store = [];
+
+        return true;
+    }
+
+    /** @param iterable<string> $keys */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $result = [];
+
+        foreach ($keys as $key) {
+            $result[$key] = $this->get($key, $default);
+        }
+
+        return $result;
+    }
+
+    /** @param iterable<string, mixed> $values */
+    public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        return true;
+    }
+
+    /** @param iterable<string> $keys */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->store);
+    }
+}
+```
+
+Note: `psr/simple-cache` is already a project dependency, so `CacheInterface` is available. `autoload-dev` maps `Fissible\Accord\Tests\` → `tests/`, so this resolves with no `composer dump-autoload`. `tests/Support` is not a PHPUnit suite, so it is not collected as a test.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/Support/ArrayCache.php
+git commit -m "test: add in-memory ArrayCache PSR-16 double (#7)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `FileSpecSource` — optional PSR-16 cache
+
+**Files:**
+- Create: `tests/Fixtures/v3.yaml`
+- Modify: `src/FileSpecSource.php`
+- Test: `tests/Unit/FileSpecSourceTest.php`
+
+The current `src/FileSpecSource.php` constructor is `(string $basePath, string $pattern = '{base}/resources/openapi/{version}')` and `load()` resolves the path then returns `Reader::readFromYamlFile($path)` / `readFromJsonFile($path)` directly. It has `exists()`, `resolvedPath()`, private `findPath()`, private `isYaml()`.
+
+- [ ] **Step 1: Create the internal-`$ref` fixture**
+
+Create `tests/Fixtures/v3.yaml`:
+
+```yaml
+openapi: '3.0.3'
+info:
+  title: Ref Spec
+  version: '3'
+paths:
+  /v3/things:
+    get:
+      operationId: things.index
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+components:
+  schemas:
+    Thing:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add `use Fissible\Accord\Tests\Support\ArrayCache;` to the imports of `tests/Unit/FileSpecSourceTest.php` (namespace `Fissible\Accord\Tests\Unit`; it already imports `FileSpecSource` and has `setUp()` setting `$this->fixturesPath = dirname(__DIR__) . '/Fixtures'`). Add these methods to the class:
+
+```php
+    public function test_cache_miss_populates_the_cache(): void
+    {
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $spec = $source->load('v1');
+
+        $this->assertNotNull($spec);
+        $this->assertCount(1, $cache->store);
+
+        $decoded = json_decode((string) array_values($cache->store)[0], true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('openapi', $decoded);
+        $this->assertArrayHasKey('paths', $decoded);
+    }
+
+    public function test_cache_hit_is_used_instead_of_the_file(): void
+    {
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $source->load('v1'); // miss → populates the cache
+
+        // Overwrite the single cached entry with a DIFFERENT spec.
+        $key = array_key_first($cache->store);
+        $cache->store[$key] = json_encode([
+            'openapi' => '3.0.3',
+            'info'    => ['title' => 'from cache', 'version' => '1'],
+            'paths'   => ['/from/cache' => ['get' => ['responses' => ['200' => ['description' => 'OK']]]]],
+        ]);
+
+        $spec = $source->load('v1'); // hit → rehydrates the overwritten value
+
+        $this->assertNotNull($spec);
+        $this->assertTrue(isset($spec->paths['/from/cache']));
+        $this->assertFalse(isset($spec->paths['/v1/users']));
+    }
+
+    public function test_invalid_cache_entry_falls_back_to_parsing(): void
+    {
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $source->load('v1');
+        $key = array_key_first($cache->store);
+        $cache->store[$key] = '{not valid openapi'; // invalid JSON → readFromJson throws
+
+        $spec = $source->load('v1'); // must re-parse the file, no throw
+
+        $this->assertNotNull($spec);
+        $this->assertTrue(isset($spec->paths['/v1/users']));
+    }
+
+    public function test_cache_failures_do_not_break_loading(): void
+    {
+        $cache = new class extends ArrayCache {
+            public function get(string $key, mixed $default = null): mixed
+            {
+                throw new \RuntimeException('cache get failed');
+            }
+
+            public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
+            {
+                throw new \RuntimeException('cache set failed');
+            }
+        };
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $spec = $source->load('v1');
+
+        $this->assertNotNull($spec);
+        $this->assertTrue(isset($spec->paths['/v1/users']));
+    }
+
+    public function test_mtime_change_invalidates_cache(): void
+    {
+        $dir  = sys_get_temp_dir() . '/accord_cache_' . uniqid();
+        mkdir($dir);
+        $file = $dir . '/v1.yaml';
+        file_put_contents($file, "openapi: '3.0.3'\ninfo: { title: t, version: '1' }\npaths:\n  /first:\n    get:\n      responses:\n        '200': { description: OK }\n");
+
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($dir, '{base}/{version}', $cache);
+
+        $first = $source->load('v1');
+        $this->assertTrue(isset($first->paths['/first']));
+
+        // Rewrite with different content and a NEW mtime; clear stat cache so filemtime re-reads.
+        file_put_contents($file, "openapi: '3.0.3'\ninfo: { title: t, version: '1' }\npaths:\n  /second:\n    get:\n      responses:\n        '200': { description: OK }\n");
+        touch($file, time() + 10);
+        clearstatcache(true, $file);
+
+        $second = $source->load('v1');
+        $this->assertTrue(isset($second->paths['/second']));
+        $this->assertFalse(isset($second->paths['/first']));
+
+        unlink($file);
+        rmdir($dir);
+    }
+
+    public function test_internal_ref_round_trips_through_cache(): void
+    {
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $first  = $source->load('v3'); // miss → file parse
+        $second = $source->load('v3'); // hit → rehydrate from cache
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertSame(
+            json_encode($first->getSerializableData()),
+            json_encode($second->getSerializableData()),
+        );
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter FileSpecSourceTest`
+Expected: FAIL — `FileSpecSource::__construct()` does not accept a 3rd argument (`$cache`).
+
+- [ ] **Step 4: Add caching to `FileSpecSource`**
+
+Replace the entire contents of `src/FileSpecSource.php` with:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord;
+
+use cebe\openapi\Reader;
+use cebe\openapi\spec\OpenApi;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Loads OpenAPI specs from the local filesystem.
+ *
+ * The pattern uses {base} and {version} tokens and should NOT include a file
+ * extension — FileSpecSource tries .yaml, .yml, and .json in that order.
+ * If your pattern already includes an extension it is used as-is.
+ *
+ * Default pattern: {base}/resources/openapi/{version}
+ *
+ * Pass an optional PSR-16 cache to persist the PARSED spec across processes
+ * (PHP-FPM): on a hit the spec is rehydrated from cached JSON, skipping the
+ * (slow) YAML parse. The cache key includes the file's mtime, so a redeployed
+ * spec auto-invalidates. In-process caching is handled by ContractValidator.
+ */
+class FileSpecSource implements SpecSourceInterface
+{
+    public function __construct(
+        private readonly string $basePath,
+        private readonly string $pattern = '{base}/resources/openapi/{version}',
+        private readonly ?CacheInterface $cache = null,
+        private readonly int $ttl = 3600,
+    ) {}
+
+    public function load(string $version): ?OpenApi
+    {
+        $path = $this->findPath($version);
+
+        if ($path === null) {
+            return null;
+        }
+
+        if ($this->cache === null) {
+            return $this->parse($path);
+        }
+
+        $cacheKey = sprintf('fissible.accord.spec.file.%s.%d', hash('xxh32', $path), @filemtime($path) ?: 0);
+
+        try {
+            $cached = $this->cache->get($cacheKey);
+        } catch (\Throwable) {
+            $cached = null; // cache get failure → treat as miss
+        }
+
+        if (is_string($cached)) {
+            try {
+                return Reader::readFromJson($cached);
+            } catch (\Throwable) {
+                // unrehydratable (invalid-JSON) cache entry → fall through to re-parse
+            }
+        }
+
+        $spec = $this->parse($path);
+        $json = json_encode($spec->getSerializableData());
+
+        if (is_string($json)) {
+            try {
+                $this->cache->set($cacheKey, $json, $this->ttl);
+            } catch (\Throwable) {
+                // caching is best-effort; never break spec loading
+            }
+        }
+
+        return $spec;
+    }
+
+    public function exists(string $version): bool
+    {
+        return $this->findPath($version) !== null;
+    }
+
+    public function resolvedPath(string $version): ?string
+    {
+        return $this->findPath($version);
+    }
+
+    private function parse(string $path): OpenApi
+    {
+        return $this->isYaml($path)
+            ? Reader::readFromYamlFile($path)
+            : Reader::readFromJsonFile($path);
+    }
+
+    private function findPath(string $version): ?string
+    {
+        $resolved = str_replace(
+            ['{base}', '{version}'],
+            [$this->basePath, $version],
+            $this->pattern,
+        );
+
+        if (file_exists($resolved)) {
+            return $resolved;
+        }
+
+        foreach (['.yaml', '.yml', '.json'] as $ext) {
+            if (file_exists($resolved . $ext)) {
+                return $resolved . $ext;
+            }
+        }
+
+        return null;
+    }
+
+    private function isYaml(string $path): bool
+    {
+        return str_ends_with($path, '.yaml') || str_ends_with($path, '.yml');
+    }
+}
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS. 137 prior + 6 new = 143 tests. Deprecations remain 5 (the v3 fixture triggers the same cebe deprecation messages, not new ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/FileSpecSource.php tests/Unit/FileSpecSourceTest.php tests/Fixtures/v3.yaml
+git commit -m "feat: optional PSR-16 cache for FileSpecSource (mtime-keyed JSON round-trip) (#7)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Laravel config — `spec_cache` + correct `spec_cache_ttl` doc
+
+**Files:**
+- Modify: `src/Drivers/Laravel/config/accord.php`
+
+No isolated test (config data); exercised by Task 4.
+
+- [ ] **Step 1: Add the `spec_cache` block**
+
+In `src/Drivers/Laravel/config/accord.php`, insert this block immediately AFTER the `'spec_pattern' => env('ACCORD_SPEC_PATTERN', ...),` line and BEFORE the existing `Spec Cache TTL` comment block:
+
+```php
+
+    /*
+    |--------------------------------------------------------------------------
+    | Spec Cache
+    |--------------------------------------------------------------------------
+    | Optional persistent cache for the PARSED spec, across requests/processes
+    | (PHP-FPM re-parses the spec on every request otherwise). Values:
+    |   null | false | '' — off (in-process cache only; the default)
+    |   true             — use the application's default cache store
+    |   'store-name'     — use a named cache store (e.g. 'redis', 'file')
+    | The file cache key includes the spec file's mtime, so a redeployed spec
+    | auto-invalidates — no manual cache flush needed. Applies to file and url
+    | sources. Long-lived workers (Octane/RoadRunner) keep an in-process parsed
+    | spec until they restart, so restart workers on deploy.
+    |
+    */
+    'spec_cache' => env('ACCORD_SPEC_CACHE', null),
+```
+
+- [ ] **Step 2: Correct the `spec_cache_ttl` comment**
+
+Replace the body of the existing `Spec Cache TTL` comment block — find:
+
+```php
+    | Seconds to cache remotely fetched specs (url source only).
+    | In standard PHP-FPM the in-process cache is sufficient; this is for
+    | serverless or short-lived process environments.
+```
+
+and replace it with:
+
+```php
+    | Seconds a cached spec lives before this TTL backstop expires. Applies to
+    | both file and url spec caches (when spec_cache is enabled). For files,
+    | mtime keying already invalidates on change; the TTL just evicts stale
+    | old-mtime entries so they don't accumulate.
+```
+
+- [ ] **Step 3: Verify syntax + suite**
+
+Run: `php -l src/Drivers/Laravel/config/accord.php` → "No syntax errors detected".
+Run: `vendor/bin/phpunit --colors=never` → 143 tests, 5 deprecations.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Drivers/Laravel/config/accord.php
+git commit -m "feat: add spec_cache config knob; correct spec_cache_ttl doc (#7)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `AccordServiceProvider` — resolve + wire cache into both sources
+
+**Files:**
+- Modify: `src/Drivers/Laravel/Providers/AccordServiceProvider.php`
+- Test: `tests/Feature/LaravelServiceProviderTest.php`
+
+The current `SpecSourceInterface` singleton closure:
+
+```php
+        $this->app->singleton(SpecSourceInterface::class, function () {
+            $type    = config('accord.spec_source', 'file');
+            $pattern = config('accord.spec_pattern');
+
+            if ($type === 'url') {
+                return new UrlSpecSource(
+                    pattern: $pattern,
+                    ttl:     (int) config('accord.spec_cache_ttl', 3600),
+                );
+            }
+
+            return new FileSpecSource(base_path(), $pattern);
+        });
+```
+
+The test file `tests/Feature/LaravelServiceProviderTest.php` (namespace `Fissible\Accord\Tests\Feature`) has the `FakeLaravelContainer` (implements `CachesConfiguration`), `LaravelConfig` (static config store), `RecordingLogger`, `FakeLogManager`. Its `setUp()` sets `LaravelConfig::$values` including `accord.spec_source => 'file'` and `accord.spec_pattern => '{base}/Fixtures/{version}'`. The global `base_path()` stub returns `dirname(__DIR__)` (the `tests/` dir).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these imports to the `Fissible\Accord\Tests\Feature` namespace `use` block (some may already be present — do not duplicate):
+
+```php
+    use Fissible\Accord\SpecSourceInterface;
+    use Fissible\Accord\Tests\Support\ArrayCache;
+    use Psr\SimpleCache\CacheInterface;
+```
+
+Add `'accord.spec_cache' => null,` to the `LaravelConfig::$values` array in `setUp()`.
+
+Add a `FakeCacheManager` class inside the `namespace Fissible\Accord\Tests\Feature { ... }` block (next to the other fake classes like `FakeLogManager`):
+
+```php
+    final class FakeCacheManager
+    {
+        public function __construct(private readonly CacheInterface $cache) {}
+
+        public function store(?string $name = null): CacheInterface
+        {
+            return $this->cache;
+        }
+    }
+```
+
+Add these two methods to the `LaravelServiceProviderTest` class (8-space method indentation, 12-space body, matching siblings):
+
+```php
+        public function test_file_spec_cache_wired_from_config(): void
+        {
+            $cache = new ArrayCache();
+            LaravelConfig::$values['accord.spec_cache']   = true;
+            LaravelConfig::$values['accord.spec_source']  = 'file';
+            LaravelConfig::$values['accord.spec_pattern'] = '{base}/Fixtures/{version}';
+
+            $app = new FakeLaravelContainer([
+                LoggerInterface::class => new RecordingLogger(),
+                'cache'                => new FakeCacheManager($cache),
+            ]);
+            (new AccordServiceProvider($app))->register();
+
+            $app->make(SpecSourceInterface::class)->load('v1');
+
+            $this->assertNotEmpty($cache->store); // resolved default store cached the parsed spec
+        }
+
+        public function test_url_spec_cache_wired_from_config(): void
+        {
+            $cache = new ArrayCache();
+            LaravelConfig::$values['accord.spec_cache']   = true;
+            LaravelConfig::$values['accord.spec_source']  = 'url';
+            LaravelConfig::$values['accord.spec_pattern'] = 'file://' . dirname(__DIR__) . '/Fixtures/{version}.yaml';
+
+            $app = new FakeLaravelContainer([
+                LoggerInterface::class => new RecordingLogger(),
+                'cache'                => new FakeCacheManager($cache),
+            ]);
+            (new AccordServiceProvider($app))->register();
+
+            $app->make(SpecSourceInterface::class)->load('v1');
+
+            $this->assertNotEmpty($cache->store); // UrlSpecSource now receives the cache (previously only a TTL)
+        }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter LaravelServiceProviderTest`
+Expected: FAIL — the provider builds the sources WITHOUT a cache, so `$cache->store` stays empty.
+
+- [ ] **Step 3: Update the provider**
+
+In `src/Drivers/Laravel/Providers/AccordServiceProvider.php`, add the import near the existing `use` statements:
+
+```php
+use Psr\SimpleCache\CacheInterface;
+```
+
+Replace the `SpecSourceInterface` singleton closure with:
+
+```php
+        $this->app->singleton(SpecSourceInterface::class, function () {
+            $type    = config('accord.spec_source', 'file');
+            $pattern = config('accord.spec_pattern');
+            $cache   = $this->resolveSpecCache();
+            $ttl     = (int) config('accord.spec_cache_ttl', 3600);
+
+            if ($type === 'url') {
+                return new UrlSpecSource(pattern: $pattern, cache: $cache, ttl: $ttl);
+            }
+
+            return new FileSpecSource(base_path(), $pattern, $cache, $ttl);
+        });
+```
+
+Add this private helper method to the class (next to the other private helpers like `resolveLogger`):
+
+```php
+    private function resolveSpecCache(): ?CacheInterface
+    {
+        $store = config('accord.spec_cache');
+
+        if ($store === null || $store === false || $store === '') {
+            return null;
+        }
+
+        return $store === true
+            ? $this->app->make('cache')->store()        // default store (NO argument — avoids store('1'))
+            : $this->app->make('cache')->store($store);  // named store
+    }
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS. 143 prior + 2 = 145 tests. Deprecations 5. Existing provider tests still pass (default `spec_cache => null` → no cache → unchanged behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Drivers/Laravel/Providers/AccordServiceProvider.php tests/Feature/LaravelServiceProviderTest.php
+git commit -m "feat: provider resolves spec cache and wires it into file + url sources (#7)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `AccordFactory` — wire cache into the file source
+
+**Files:**
+- Modify: `src/AccordFactory.php`
+- Test: `tests/Unit/AccordFactoryTest.php`
+
+The current `makeSpecSource` file branch (the URL branch already passes `$config['spec_cache']`):
+
+```php
+        return new FileSpecSource(
+            $basePath,
+            $config['spec_pattern'] ?? '{base}/resources/openapi/{version}',
+        );
+```
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/Unit/AccordFactoryTest.php` (namespace `Fissible\Accord\Tests\Unit`; it already imports `AccordFactory`, `Nyholm\Psr7\ServerRequest`, and has a `passthroughHandler()` helper), add `use Fissible\Accord\Tests\Support\ArrayCache;` and this test:
+
+```php
+    public function test_factory_wires_file_spec_cache(): void
+    {
+        $cache = new ArrayCache();
+
+        $middleware = AccordFactory::make(
+            ['spec_source' => 'file', 'spec_pattern' => '{base}/{version}', 'spec_cache' => $cache],
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        // GET /v1/users loads the spec (then skips as missing_request_schema — no params/body, no throw).
+        $middleware->process(new ServerRequest('GET', '/v1/users'), $this->passthroughHandler());
+
+        $this->assertNotEmpty($cache->store);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter AccordFactoryTest`
+Expected: FAIL — the factory's `FileSpecSource` is built without the cache, so `$cache->store` stays empty.
+
+- [ ] **Step 3: Pass the cache in the factory**
+
+In `src/AccordFactory.php`, replace the file-branch `return new FileSpecSource(...)` shown above with:
+
+```php
+        return new FileSpecSource(
+            $basePath,
+            $config['spec_pattern'] ?? '{base}/resources/openapi/{version}',
+            $config['spec_cache'] ?? null,
+            (int) ($config['spec_cache_ttl'] ?? 3600),
+        );
+```
+
+Also update the class docblock's "Config keys (all optional):" list — the `spec_cache` entry currently (if present) implies URL-only; ensure there is a line describing it for both sources. Add or adjust to:
+
+```php
+ *   spec_cache       — Psr\SimpleCache\CacheInterface|null; persists the parsed spec across
+ *                      processes (file + url sources)         (default: null = in-process only)
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS. 145 prior + 1 = 146 tests. Deprecations 5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/AccordFactory.php tests/Unit/AccordFactoryTest.php
+git commit -m "feat: AccordFactory wires spec_cache into the file source (#7)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: README documentation
+
+**Files:**
+- Modify: `README.md`
+
+No test (docs).
+
+- [ ] **Step 1: Add config lines**
+
+In `README.md`, find the Laravel published-config snippet (it contains `'spec_pattern' => ...` and `'spec_cache_ttl' => ...`). Add a `spec_cache` line immediately after the `spec_pattern` line:
+
+```php
+    'spec_cache'     => env('ACCORD_SPEC_CACHE', null),         // null|true|'store' — persist the parsed spec
+```
+
+- [ ] **Step 2: Add a "Caching the spec" subsection**
+
+Immediately after that config snippet's closing ``` fence, insert this markdown:
+
+```markdown
+**Caching the spec.** `FileSpecSource` parses the OpenAPI file on every `load()`, and in
+PHP-FPM each request is a fresh process — so the (slow) YAML parse runs per request. Enable
+a persistent cache to parse once and rehydrate from cached JSON on subsequent requests
+(roughly an order of magnitude faster):
+
+- **`spec_cache`** — `null`/`false` = off (in-process cache only; the default), `true` = the
+  application's default cache store, or a store name (e.g. `'redis'`). The resolved cache is
+  wired into both file and URL sources.
+- **Invalidation is automatic for files:** the cache key includes the spec file's
+  modification time, so a redeployed/edited spec produces a new key and is re-parsed — no
+  `cache:clear` needed. `spec_cache_ttl` is just a backstop that evicts stale old-mtime
+  entries.
+
+Two caveats:
+
+- **Long-lived workers (Octane/RoadRunner):** `ContractValidator` keeps an in-process parsed
+  spec per version for the life of the worker, so mtime invalidation only helps fresh
+  processes (PHP-FPM). Restart workers on deploy (these stacks already do) to pick up a
+  changed spec.
+- **External `$ref`s:** the cache stores the spec's *serialized data*, so specs that rely on
+  **external-file** `$ref`s may not round-trip — keep specs self-contained. Internal
+  `#/components` refs are fine.
+
+For Slim/Mezzio, pass a PSR-16 cache instance directly: `AccordFactory::make(['spec_cache' => $psr16, ...], $basePath)`.
+```
+
+- [ ] **Step 3: Verify suite + fences**
+
+Run: `vendor/bin/phpunit --colors=never` → 146 tests, 5 deprecations.
+Run: `grep -c '```' README.md` → must be EVEN.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document spec caching (config, mtime invalidation, caveats) (#7)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Full suite + clean tree**
+
+```bash
+vendor/bin/phpunit --colors=never
+git diff --check
+```
+Expected: 146 tests pass, 5 deprecations (no new). `git diff --check` prints nothing.
+
+- [ ] **Step 2: Core stayed framework-agnostic**
+
+```bash
+grep -rn 'Illuminate\\' src/ | grep -v src/Drivers/
+```
+Expected: no output.
+
+- [ ] **Step 3: Push + PR (only if the user asks)**
+
+Do not push/PR unless asked. When asked:
+
+```bash
+git push -u origin feat/file-spec-cache
+gh pr create --title "feat: persistent cache for file-backed specs (#7)" --body "$(cat <<'EOF'
+Implements #7. Persists the parsed spec across requests so PHP-FPM doesn't re-parse YAML every request.
+
+- `FileSpecSource` gains an optional PSR-16 cache (mirrors `UrlSpecSource`). Miss → parse + store `json_encode(getSerializableData())`; hit → `Reader::readFromJson` (~15× faster than YAML parse, benchmarked).
+- Cache key includes the file's **mtime** → a redeployed spec auto-invalidates (no flush); TTL evicts stale entries.
+- Resilient: cache get/set failures and invalid-JSON entries fall back to parsing; malformed local specs still throw.
+- Laravel `spec_cache` config (null | true | store-name) + provider wiring — also **fixes the dead URL-cache wiring** (the provider previously passed only a TTL to `UrlSpecSource`). `AccordFactory` wires the file cache too.
+- Docs cover mtime invalidation + the long-lived-worker and external-`$ref` caveats.
+
+Backward compatible: cache defaults to null everywhere → unchanged behavior; new ctor params trailing.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** ArrayCache double (T1), FileSpecSource cache + mtime key + JSON round-trip + corrupt/failure resilience + internal-ref fidelity + v3 fixture (T2), config `spec_cache` + corrected `spec_cache_ttl` doc (T3), provider resolveSpecCache (true→default store, not store('1')) + wire both sources + file & url tests (T4), factory file-cache wiring (T5), README incl. both caveats (T6), framework-agnostic guard (T7). The "fix dead URL wiring" requirement is covered by T4's `test_url_spec_cache_wired_from_config`.
+- **Type consistency:** `FileSpecSource(basePath, pattern, ?CacheInterface $cache = null, int $ttl = 3600)` used identically in T2/T4/T5; key format `fissible.accord.spec.file.{xxh32}.{mtime}`; `resolveSpecCache(): ?CacheInterface`; ArrayCache `$store` public array used across tests.
+- **No placeholders:** every code step shows full code; the round-trip + mtime behavior were reality-checked (benchmark + ref probe) before writing; expected counts cumulative (137→146).

--- a/docs/superpowers/specs/2026-06-16-file-spec-cache-design.md
+++ b/docs/superpowers/specs/2026-06-16-file-spec-cache-design.md
@@ -1,0 +1,231 @@
+# Persistent cache for file-backed specs (#7)
+
+**Date:** 2026-06-16
+**Issue:** #7 (persistent cache support for file-backed specs)
+**Package state:** accord is at v1.2.0 (+#8 merged, unreleased). This is additive and backward compatible.
+
+## Problem
+
+`FileSpecSource` parses the OpenAPI file (YAML/JSON) on every `load()`. In PHP-FPM each
+request is a fresh process, so the spec is re-parsed every request. YAML parsing
+(symfony/yaml, pure PHP) is the dominant cost. `ContractValidator`'s in-process cache only
+helps within a single process; nothing persists across requests.
+
+## Validated assumption (benchmark)
+
+`Reader::readFromJson(json_encode($spec->getSerializableData()))` reconstructs an equivalent
+`OpenApi` (verified: same operation resolved). Timing on the `v1.yaml` fixture: YAML parse
+**0.92 ms/op** vs JSON rehydrate **0.06 ms/op** → **~15×** faster. The gap widens for larger
+specs (YAML parsing scales worse than native `json_decode`). So: cache the parsed spec as
+JSON, rehydrate on a hit.
+
+## Decisions (confirmed with user)
+
+- **Cache format:** store `json_encode($spec->getSerializableData())`; rehydrate via
+  `Reader::readFromJson`; a corrupt cache entry is treated as a miss (re-parse).
+- **Invalidation:** `mtime` in the cache key → a redeployed/edited spec auto-invalidates
+  (new key → miss → re-parse), no manual flush. TTL evicts stale-mtime entries.
+- **Wiring:** one resolved cache feeds **both** `FileSpecSource` and `UrlSpecSource` (the
+  Laravel provider currently passes only a TTL to `UrlSpecSource`, so URL caching is dead
+  there today — this fixes it).
+- **`spec_cache` config:** `null`/`false`/`''` = off, `true` = default store, string =
+  named store.
+- **External `$ref` caveat:** documented, not engineered around (YAGNI). A plan test
+  confirms an **internal** `#/components` `$ref` spec round-trips through the cache.
+
+## Architecture
+
+The core (`src/` excluding `src/Drivers/`) stays framework-agnostic. `psr/simple-cache` is
+already a dependency; `FileSpecSource` mirrors `UrlSpecSource`'s optional-PSR-16 shape.
+
+### Components (dependency order, leaves → roots)
+
+1. **`FileSpecSource` — optional PSR-16 cache** (core). New trailing ctor params:
+   ```php
+   public function __construct(
+       private readonly string $basePath,
+       private readonly string $pattern = '{base}/resources/openapi/{version}',
+       private readonly ?CacheInterface $cache = null,
+       private readonly int $ttl = 3600,
+   ) {}
+   ```
+   `load($version)`:
+   ```php
+   $path = $this->findPath($version);
+   if ($path === null) {
+       return null;                       // unchanged: no spec → no constraint
+   }
+   if ($this->cache === null) {
+       return $this->parse($path);        // unchanged behavior for non-cache callers
+   }
+
+   $cacheKey = sprintf('fissible.accord.spec.file.%s.%d', hash('xxh32', $path), @filemtime($path) ?: 0);
+
+   try {
+       $cached = $this->cache->get($cacheKey);
+   } catch (\Throwable) {
+       $cached = null;                    // cache get failure → treat as miss
+   }
+
+   if (is_string($cached)) {
+       try {
+           return Reader::readFromJson($cached);   // throws only on INVALID json; see note below
+       } catch (\Throwable) {
+           // unrehydratable cache entry → fall through to re-parse
+       }
+   }
+
+   $spec = $this->parse($path);
+
+   if ($spec !== null) {
+       $json = json_encode($spec->getSerializableData());
+       if (is_string($json)) {            // never set() a failed encode
+           try {
+               $this->cache->set($cacheKey, $json, $this->ttl);
+           } catch (\Throwable) {
+               // caching is best-effort; never break spec loading
+           }
+       }
+   }
+
+   return $spec;
+   ```
+   The existing parse logic is extracted into:
+   ```php
+   private function parse(string $path): ?OpenApi
+   {
+       return $this->isYaml($path)
+           ? Reader::readFromYamlFile($path)
+           : Reader::readFromJsonFile($path);
+   }
+   ```
+   - **Distinct key namespace** `fissible.accord.spec.file.{xxh32(path)}.{mtime}` —
+     `UrlSpecSource` stores *raw content* under `fissible.accord.spec.{xxh32(url)}`;
+     `FileSpecSource` stores *serialized JSON*. The `.file.` segment prevents any
+     format confusion if they ever share a store.
+   - **Parse-error semantics unchanged:** a malformed local spec still throws (a deploy
+     error worth surfacing). Only cache get/set/rehydrate are defensive — cache failures
+     never break spec loading.
+   - **Corrupt-cache scope (cebe caveat):** `Reader::readFromJson` only **throws** on
+     *invalid* JSON (which the try/catch catches → re-parse). Valid-JSON-but-not-a-spec
+     (e.g. `'{}'`) does **not** throw — cebe returns a (possibly empty) `OpenApi`. We do
+     **not** add a shape guard for that, because the namespaced key
+     (`fissible.accord.spec.file.{hash}.{mtime}`) only ever holds our own
+     `getSerializableData()` writes; a foreign valid-JSON entry is not a real scenario.
+     The guarantee is therefore: an *unrehydratable* (invalid-JSON) entry falls back to
+     parsing — not "any non-spec content".
+   - `findPath`, `isYaml`, `resolvedPath`, `exists` unchanged.
+
+2. **Laravel config `accord.php`:**
+   - Add `'spec_cache' => env('ACCORD_SPEC_CACHE', null)`, documented: `null`/`false`/`''` =
+     off (in-process only, today's behavior), `true` = Laravel's default cache store, a
+     string = a named store.
+   - Update the existing `spec_cache_ttl` comment: it is **no longer URL-only** — it is the
+     TTL backstop for both file and URL spec caches.
+
+3. **`AccordServiceProvider`** — a `resolveSpecCache(): ?CacheInterface` helper, written to
+   avoid the `true`→`store('1')` footgun:
+   ```php
+   private function resolveSpecCache(): ?CacheInterface
+   {
+       $store = config('accord.spec_cache');
+
+       if ($store === null || $store === false || $store === '') {
+           return null;
+       }
+
+       return $store === true
+           ? $this->app->make('cache')->store()           // default store (NO argument)
+           : $this->app->make('cache')->store($store);     // named store
+   }
+   ```
+   (Laravel cache repositories implement `Psr\SimpleCache\CacheInterface`.) The
+   `SpecSourceInterface` singleton resolves the cache once and passes it to **both** sources
+   with `spec_cache_ttl`:
+   ```php
+   $cache = $this->resolveSpecCache();
+   $ttl   = (int) config('accord.spec_cache_ttl', 3600);
+   if ($type === 'url') {
+       return new UrlSpecSource(pattern: $pattern, cache: $cache, ttl: $ttl);
+   }
+   return new FileSpecSource(base_path(), $pattern, $cache, $ttl);
+   ```
+
+4. **`AccordFactory`** (Slim/Mezzio) — `makeSpecSource` already passes
+   `$config['spec_cache']` (a PSR-16 instance) to `UrlSpecSource`; add the same instance +
+   `(int) ($config['spec_cache_ttl'] ?? 3600)` to the `FileSpecSource` branch.
+
+5. **README** — a "Caching the spec" subsection: when to enable (PHP-FPM re-parses the spec
+   per request), the `spec_cache` config shape, mtime invalidation (no flush on deploy), and
+   two caveats:
+   - **Long-lived workers (Octane/RoadRunner):** `ContractValidator` keeps an in-process
+     parsed spec per version for the life of the worker, so mtime invalidation only helps
+     fresh validator instances (PHP-FPM, new processes). Long-lived workers keep the old
+     parsed spec until the worker restarts — restart workers on deploy (which these stacks
+     already do).
+   - **External `$ref`s:** the cache stores the spec's serialized data; specs relying on
+     **external-file** `$ref`s may not round-trip — keep specs self-contained. Internal
+     `#/components` refs are fine.
+
+## Error handling / backward compatibility
+
+- `cache` defaults to `null` everywhere → identical behavior for anyone not opting in.
+- New `FileSpecSource` ctor params are optional and trailing; `SpecSourceInterface` unchanged.
+- Cache get/set failures and corrupt/unencodable entries fall back to parsing; malformed
+  local specs still throw as before.
+
+## Testing (TDD, one behavior per test)
+
+Test double: a small in-memory PSR-16 cache — `tests/Support/ArrayCache.php` implementing
+`Psr\SimpleCache\CacheInterface` over a public `$store` array (all 8 methods; the unused
+multi/has methods are trivial).
+
+`FileSpecSource` (unit, `tests/Unit/FileSpecSourceTest.php`):
+- No cache (null) → loads/parses as before (existing tests already cover this; keep green).
+- Cache miss populates the cache: load with an `ArrayCache` → `$store` has exactly one entry
+  whose value is JSON that rehydrates (via `Reader::readFromJson`) to a spec exposing the
+  expected operation.
+- Cache hit is used: load once (populates), then overwrite the single stored value with a
+  *different* spec's JSON, load again → returned spec reflects the **cached** content (proves
+  the hit path rehydrates from cache, not the file).
+- Unrehydratable cache entry → overwrite the stored value with **invalid JSON**
+  (`'{not valid openapi'`, which makes `Reader::readFromJson` throw) → load returns a valid
+  spec by re-parsing the file (no throw). (Do not assert on valid-JSON-non-spec content —
+  cebe does not throw on `'{}'`; see the corrupt-cache caveat above.)
+- Cache failure resilience: an `ArrayCache` subclass whose `get`/`set` throw → load still
+  returns the parsed spec.
+- mtime invalidation (validate-against-reality): write a temp spec file, load (cache
+  populated), modify its contents and bump mtime (`touch($file, time()+10)`), load again →
+  the returned spec reflects the **new** file contents (new mtime ⇒ new key ⇒ re-parse).
+- Internal `$ref` round-trips faithfully: a fixture spec using
+  `$ref: '#/components/schemas/X'`. (Reality-checked: cebe keeps internal refs as
+  `Reference` objects — it does NOT auto-resolve them, in both the cached and uncached
+  paths.) Load-with-cache twice and assert
+  `json_encode($first->getSerializableData()) === json_encode($second->getSerializableData())`
+  — the cache-hit rehydration reproduces the file-parsed structure byte-for-byte, including
+  the `$ref`. (Do not assert the ref resolves to a concrete schema — it doesn't, cached or
+  not.)
+
+Laravel provider / factory:
+- Provider (file): bind a fake `cache` manager whose `store()` returns an `ArrayCache`; set
+  `accord.spec_cache => true`, `accord.spec_source => file`; resolve `SpecSourceInterface`;
+  load a fixture version → the `ArrayCache` gains an entry (proves provider wiring +
+  `true` → default store, not `store('1')`).
+- Provider (url — proves the dead URL-cache wiring is fixed): bind a fake `cache` manager
+  whose `store()` returns an `ArrayCache`; set `accord.spec_cache => true`,
+  `accord.spec_source => url`, and `accord.spec_pattern => 'file://' . <abs fixtures dir> .
+  '/{version}.yaml'` (a `file://` URL is fetchable by `UrlSpecSource`'s `file_get_contents`);
+  resolve `SpecSourceInterface`; `load('v1')` → the `ArrayCache` gains an entry (proves the
+  resolved cache is now passed to `UrlSpecSource`, which previously received only a TTL).
+- `AccordFactory`: pass `spec_cache` (an `ArrayCache` instance) + `spec_source => file`;
+  build the middleware; process a `/v1/...` request that loads the spec → the `ArrayCache`
+  is populated (proves factory file-cache wiring).
+
+Whole suite stays green (currently 137) with no new deprecations.
+
+## Out of scope (YAGNI)
+
+- Changing `ContractValidator`'s in-process cache (worker staleness is documented, not fixed).
+- Supporting external-file `$ref`s through the cache.
+- A CLI cache-warm/clear command (mtime keying + Laravel `cache:clear` suffice).
+- Compiling specs to opcache-able PHP files (PSR-16 mirrors the existing pattern).

--- a/src/AccordFactory.php
+++ b/src/AccordFactory.php
@@ -22,6 +22,8 @@ use Psr\Log\NullLogger;
  *   spec_pattern     — path/URL template with {base} and {version} tokens
  *                      file default: '{base}/resources/openapi/{version}'
  *                      url example:  'https://api.example.com/openapi/{version}.yaml'
+ *   spec_cache       — Psr\SimpleCache\CacheInterface|null; persists the parsed spec across
+ *                      processes (file + url sources)         (default: null = in-process only)
  *   spec_cache_ttl   — PSR-16 cache TTL in seconds for URL source (default: 3600)
  *   debug            — bool; log skipped (non-validated) requests/responses and why.
  *                      Requires a logger to produce output (see below) (default: false)
@@ -83,6 +85,8 @@ final class AccordFactory
         return new FileSpecSource(
             $basePath,
             $config['spec_pattern'] ?? '{base}/resources/openapi/{version}',
+            $config['spec_cache'] ?? null,
+            (int) ($config['spec_cache_ttl'] ?? 3600),
         );
     }
 }

--- a/src/Drivers/Laravel/Providers/AccordServiceProvider.php
+++ b/src/Drivers/Laravel/Providers/AccordServiceProvider.php
@@ -15,6 +15,7 @@ use Fissible\Accord\UrlSpecSource;
 use Fissible\Accord\VersionExtractor;
 use Illuminate\Support\ServiceProvider;
 use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
 
 class AccordServiceProvider extends ServiceProvider
 {
@@ -32,15 +33,14 @@ class AccordServiceProvider extends ServiceProvider
         $this->app->singleton(SpecSourceInterface::class, function () {
             $type    = config('accord.spec_source', 'file');
             $pattern = config('accord.spec_pattern');
+            $cache   = $this->resolveSpecCache();
+            $ttl     = (int) config('accord.spec_cache_ttl', 3600);
 
             if ($type === 'url') {
-                return new UrlSpecSource(
-                    pattern: $pattern,
-                    ttl:     (int) config('accord.spec_cache_ttl', 3600),
-                );
+                return new UrlSpecSource(pattern: $pattern, cache: $cache, ttl: $ttl);
             }
 
-            return new FileSpecSource(base_path(), $pattern);
+            return new FileSpecSource(base_path(), $pattern, $cache, $ttl);
         });
 
         $this->app->singleton(ContractValidator::class, function () {
@@ -100,5 +100,18 @@ class AccordServiceProvider extends ServiceProvider
         }
 
         return $this->app->make(LoggerInterface::class);
+    }
+
+    private function resolveSpecCache(): ?CacheInterface
+    {
+        $store = config('accord.spec_cache');
+
+        if ($store === null || $store === false || $store === '') {
+            return null;
+        }
+
+        return $store === true
+            ? $this->app->make('cache')->store()        // default store (NO argument — avoids store('1'))
+            : $this->app->make('cache')->store($store);  // named store
     }
 }

--- a/src/Drivers/Laravel/config/accord.php
+++ b/src/Drivers/Laravel/config/accord.php
@@ -81,11 +81,29 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Spec Cache
+    |--------------------------------------------------------------------------
+    | Optional persistent cache for the PARSED spec, across requests/processes
+    | (PHP-FPM re-parses the spec on every request otherwise). Values:
+    |   null | false | '' — off (in-process cache only; the default)
+    |   true             — use the application's default cache store
+    |   'store-name'     — use a named cache store (e.g. 'redis', 'file')
+    | The file cache key includes the spec file's mtime, so a redeployed spec
+    | auto-invalidates — no manual cache flush needed. Applies to file and url
+    | sources. Long-lived workers (Octane/RoadRunner) keep an in-process parsed
+    | spec until they restart, so restart workers on deploy.
+    |
+    */
+    'spec_cache' => env('ACCORD_SPEC_CACHE', null),
+
+    /*
+    |--------------------------------------------------------------------------
     | Spec Cache TTL
     |--------------------------------------------------------------------------
-    | Seconds to cache remotely fetched specs (url source only).
-    | In standard PHP-FPM the in-process cache is sufficient; this is for
-    | serverless or short-lived process environments.
+    | Seconds a cached spec lives before this TTL backstop expires. Applies to
+    | both file and url spec caches (when spec_cache is enabled). For files,
+    | mtime keying already invalidates on change; the TTL just evicts stale
+    | old-mtime entries so they don't accumulate.
     |
     */
     'spec_cache_ttl' => env('ACCORD_SPEC_CACHE_TTL', 3600),

--- a/src/FileSpecSource.php
+++ b/src/FileSpecSource.php
@@ -6,6 +6,7 @@ namespace Fissible\Accord;
 
 use cebe\openapi\Reader;
 use cebe\openapi\spec\OpenApi;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * Loads OpenAPI specs from the local filesystem.
@@ -15,12 +16,19 @@ use cebe\openapi\spec\OpenApi;
  * If your pattern already includes an extension it is used as-is.
  *
  * Default pattern: {base}/resources/openapi/{version}
+ *
+ * Pass an optional PSR-16 cache to persist the PARSED spec across processes
+ * (PHP-FPM): on a hit the spec is rehydrated from cached JSON, skipping the
+ * (slow) YAML parse. The cache key includes the file's mtime, so a redeployed
+ * spec auto-invalidates. In-process caching is handled by ContractValidator.
  */
 class FileSpecSource implements SpecSourceInterface
 {
     public function __construct(
         private readonly string $basePath,
         private readonly string $pattern = '{base}/resources/openapi/{version}',
+        private readonly ?CacheInterface $cache = null,
+        private readonly int $ttl = 3600,
     ) {}
 
     public function load(string $version): ?OpenApi
@@ -31,9 +39,38 @@ class FileSpecSource implements SpecSourceInterface
             return null;
         }
 
-        return $this->isYaml($path)
-            ? Reader::readFromYamlFile($path)
-            : Reader::readFromJsonFile($path);
+        if ($this->cache === null) {
+            return $this->parse($path);
+        }
+
+        $cacheKey = sprintf('fissible.accord.spec.file.%s.%d', hash('xxh32', $path), @filemtime($path) ?: 0);
+
+        try {
+            $cached = $this->cache->get($cacheKey);
+        } catch (\Throwable) {
+            $cached = null; // cache get failure → treat as miss
+        }
+
+        if (is_string($cached)) {
+            try {
+                return Reader::readFromJson($cached);
+            } catch (\Throwable) {
+                // unrehydratable (invalid-JSON) cache entry → fall through to re-parse
+            }
+        }
+
+        $spec = $this->parse($path);
+        $json = json_encode($spec->getSerializableData());
+
+        if (is_string($json)) {
+            try {
+                $this->cache->set($cacheKey, $json, $this->ttl);
+            } catch (\Throwable) {
+                // caching is best-effort; never break spec loading
+            }
+        }
+
+        return $spec;
     }
 
     public function exists(string $version): bool
@@ -44,6 +81,13 @@ class FileSpecSource implements SpecSourceInterface
     public function resolvedPath(string $version): ?string
     {
         return $this->findPath($version);
+    }
+
+    private function parse(string $path): OpenApi
+    {
+        return $this->isYaml($path)
+            ? Reader::readFromYamlFile($path)
+            : Reader::readFromJsonFile($path);
     }
 
     private function findPath(string $version): ?string

--- a/tests/Feature/LaravelServiceProviderTest.php
+++ b/tests/Feature/LaravelServiceProviderTest.php
@@ -50,12 +50,15 @@ namespace Fissible\Accord\Tests\Feature {
     use Fissible\Accord\Drivers\Laravel\Http\Middleware\ValidateApiContract;
     use Fissible\Accord\Drivers\Laravel\Providers\AccordServiceProvider;
     use Fissible\Accord\Exception\ContractViolationException;
+    use Fissible\Accord\SpecSourceInterface;
+    use Fissible\Accord\Tests\Support\ArrayCache;
     use Fissible\Accord\Tests\Support\RecordingLogger;
     use Fissible\Accord\ValidationResult;
     use Illuminate\Contracts\Foundation\CachesConfiguration;
     use Nyholm\Psr7\ServerRequest;
     use PHPUnit\Framework\TestCase;
     use Psr\Log\LoggerInterface;
+    use Psr\SimpleCache\CacheInterface;
     use ReflectionProperty;
 
     class LaravelServiceProviderTest extends TestCase
@@ -68,6 +71,7 @@ namespace Fissible\Accord\Tests\Feature {
                 'accord.version_pattern'   => '/^\/v(\d+)(?:\/|$)/',
                 'accord.spec_source'       => 'file',
                 'accord.spec_pattern'      => '{base}/Fixtures/{version}',
+                'accord.spec_cache'        => null,
                 'accord.spec_cache_ttl'    => 3600,
                 'accord.log_channel'              => null,
                 'accord.request_violation_status' => 422,
@@ -199,6 +203,42 @@ namespace Fissible\Accord\Tests\Feature {
             $this->assertSame(\Fissible\Accord\SkipReason::Excluded, $result->skipReason);
         }
 
+        public function test_file_spec_cache_wired_from_config(): void
+        {
+            $cache = new ArrayCache();
+            LaravelConfig::$values['accord.spec_cache']   = true;
+            LaravelConfig::$values['accord.spec_source']  = 'file';
+            LaravelConfig::$values['accord.spec_pattern'] = '{base}/Fixtures/{version}';
+
+            $app = new FakeLaravelContainer([
+                LoggerInterface::class => new RecordingLogger(),
+                'cache'                => new FakeCacheManager($cache),
+            ]);
+            (new AccordServiceProvider($app))->register();
+
+            $app->make(SpecSourceInterface::class)->load('v1');
+
+            $this->assertNotEmpty($cache->store); // resolved default store cached the parsed spec
+        }
+
+        public function test_url_spec_cache_wired_from_config(): void
+        {
+            $cache = new ArrayCache();
+            LaravelConfig::$values['accord.spec_cache']   = true;
+            LaravelConfig::$values['accord.spec_source']  = 'url';
+            LaravelConfig::$values['accord.spec_pattern'] = 'file://' . dirname(__DIR__) . '/Fixtures/{version}.yaml';
+
+            $app = new FakeLaravelContainer([
+                LoggerInterface::class => new RecordingLogger(),
+                'cache'                => new FakeCacheManager($cache),
+            ]);
+            (new AccordServiceProvider($app))->register();
+
+            $app->make(SpecSourceInterface::class)->load('v1');
+
+            $this->assertNotEmpty($cache->store); // UrlSpecSource now receives the cache (previously only a TTL)
+        }
+
         private function readStatus(ValidateApiContract $middleware): int
         {
             $property = new ReflectionProperty(ValidateApiContract::class, 'requestViolationStatus');
@@ -288,6 +328,16 @@ namespace Fissible\Accord\Tests\Feature {
             $this->requestedChannel = $channel;
 
             return $this->logger;
+        }
+    }
+
+    final class FakeCacheManager
+    {
+        public function __construct(private readonly CacheInterface $cache) {}
+
+        public function store(?string $name = null): CacheInterface
+        {
+            return $this->cache;
         }
     }
 }

--- a/tests/Fixtures/v3.yaml
+++ b/tests/Fixtures/v3.yaml
@@ -1,0 +1,24 @@
+openapi: '3.0.3'
+info:
+  title: Ref Spec
+  version: '3'
+paths:
+  /v3/things:
+    get:
+      operationId: things.index
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+components:
+  schemas:
+    Thing:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer

--- a/tests/Support/ArrayCache.php
+++ b/tests/Support/ArrayCache.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fissible\Accord\Tests\Support;
+
+use DateInterval;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Minimal in-memory PSR-16 cache for tests. The public $store array makes the
+ * cached entries inspectable/overwritable. Not for production use.
+ */
+class ArrayCache implements CacheInterface
+{
+    /** @var array<string, mixed> */
+    public array $store = [];
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->store[$key] ?? $default;
+    }
+
+    public function set(string $key, mixed $value, DateInterval|int|null $ttl = null): bool
+    {
+        $this->store[$key] = $value;
+
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        unset($this->store[$key]);
+
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        $this->store = [];
+
+        return true;
+    }
+
+    /** @param iterable<string> $keys */
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $result = [];
+
+        foreach ($keys as $key) {
+            $result[$key] = $this->get($key, $default);
+        }
+
+        return $result;
+    }
+
+    /** @param iterable<string, mixed> $values */
+    public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        return true;
+    }
+
+    /** @param iterable<string> $keys */
+    public function deleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->store);
+    }
+}

--- a/tests/Unit/AccordFactoryTest.php
+++ b/tests/Unit/AccordFactoryTest.php
@@ -8,6 +8,7 @@ use Fissible\Accord\AccordFactory;
 use Fissible\Accord\AccordMiddleware;
 use Fissible\Accord\Drivers\Mezzio\AccordMiddleware as MezzioMiddleware;
 use Fissible\Accord\Drivers\Slim\AccordMiddleware as SlimMiddleware;
+use Fissible\Accord\Tests\Support\ArrayCache;
 use Fissible\Accord\Tests\Support\RecordingLogger;
 use Nyholm\Psr7\Response;
 use Nyholm\Psr7\ServerRequest;
@@ -164,5 +165,20 @@ class AccordFactoryTest extends TestCase
 
         $reasons = array_column(array_column($logger->records, 'context'), 'reason');
         $this->assertContains('response_validation_disabled', $reasons);
+    }
+
+    public function test_factory_wires_file_spec_cache(): void
+    {
+        $cache = new ArrayCache();
+
+        $middleware = AccordFactory::make(
+            ['spec_source' => 'file', 'spec_pattern' => '{base}/{version}', 'spec_cache' => $cache],
+            dirname(__DIR__) . '/Fixtures',
+        );
+
+        // GET /v1/users loads the spec (then skips as missing_request_schema — no params/body, no throw).
+        $middleware->process(new ServerRequest('GET', '/v1/users'), $this->passthroughHandler());
+
+        $this->assertNotEmpty($cache->store);
     }
 }

--- a/tests/Unit/FileSpecSourceTest.php
+++ b/tests/Unit/FileSpecSourceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fissible\Accord\Tests\Unit;
 
 use Fissible\Accord\FileSpecSource;
+use Fissible\Accord\Tests\Support\ArrayCache;
 use PHPUnit\Framework\TestCase;
 
 class FileSpecSourceTest extends TestCase
@@ -83,6 +84,120 @@ class FileSpecSourceTest extends TestCase
             '/var/www/app/resources/openapi/v1',
             // Access via a custom fixture path to check resolution
             str_replace('{base}', '/var/www/app', str_replace('{version}', 'v1', '{base}/resources/openapi/{version}')),
+        );
+    }
+
+    public function test_cache_miss_populates_the_cache(): void
+    {
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $spec = $source->load('v1');
+
+        $this->assertNotNull($spec);
+        $this->assertCount(1, $cache->store);
+
+        $decoded = json_decode((string) array_values($cache->store)[0], true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('openapi', $decoded);
+        $this->assertArrayHasKey('paths', $decoded);
+    }
+
+    public function test_cache_hit_is_used_instead_of_the_file(): void
+    {
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $source->load('v1'); // miss → populates the cache
+
+        $key = array_key_first($cache->store);
+        $cache->store[$key] = json_encode([
+            'openapi' => '3.0.3',
+            'info'    => ['title' => 'from cache', 'version' => '1'],
+            'paths'   => ['/from/cache' => ['get' => ['responses' => ['200' => ['description' => 'OK']]]]],
+        ]);
+
+        $spec = $source->load('v1'); // hit → rehydrates the overwritten value
+
+        $this->assertNotNull($spec);
+        $this->assertTrue(isset($spec->paths['/from/cache']));
+        $this->assertFalse(isset($spec->paths['/v1/users']));
+    }
+
+    public function test_invalid_cache_entry_falls_back_to_parsing(): void
+    {
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $source->load('v1');
+        $key = array_key_first($cache->store);
+        $cache->store[$key] = '{not valid openapi'; // invalid JSON → readFromJson throws
+
+        $spec = $source->load('v1'); // must re-parse the file, no throw
+
+        $this->assertNotNull($spec);
+        $this->assertTrue(isset($spec->paths['/v1/users']));
+    }
+
+    public function test_cache_failures_do_not_break_loading(): void
+    {
+        $cache = new class extends ArrayCache {
+            public function get(string $key, mixed $default = null): mixed
+            {
+                throw new \RuntimeException('cache get failed');
+            }
+
+            public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
+            {
+                throw new \RuntimeException('cache set failed');
+            }
+        };
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $spec = $source->load('v1');
+
+        $this->assertNotNull($spec);
+        $this->assertTrue(isset($spec->paths['/v1/users']));
+    }
+
+    public function test_mtime_change_invalidates_cache(): void
+    {
+        $dir  = sys_get_temp_dir() . '/accord_cache_' . uniqid();
+        mkdir($dir);
+        $file = $dir . '/v1.yaml';
+        file_put_contents($file, "openapi: '3.0.3'\ninfo: { title: t, version: '1' }\npaths:\n  /first:\n    get:\n      responses:\n        '200': { description: OK }\n");
+
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($dir, '{base}/{version}', $cache);
+
+        $first = $source->load('v1');
+        $this->assertTrue(isset($first->paths['/first']));
+
+        file_put_contents($file, "openapi: '3.0.3'\ninfo: { title: t, version: '1' }\npaths:\n  /second:\n    get:\n      responses:\n        '200': { description: OK }\n");
+        touch($file, time() + 10);
+        clearstatcache(true, $file);
+
+        $second = $source->load('v1');
+        $this->assertTrue(isset($second->paths['/second']));
+        $this->assertFalse(isset($second->paths['/first']));
+
+        unlink($file);
+        rmdir($dir);
+    }
+
+    public function test_internal_ref_round_trips_through_cache(): void
+    {
+        $cache  = new ArrayCache();
+        $source = new FileSpecSource($this->fixturesPath, '{base}/{version}', $cache);
+
+        $first  = $source->load('v3'); // miss → file parse
+        $second = $source->load('v3'); // hit → rehydrate from cache
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertSame(
+            json_encode($first->getSerializableData()),
+            json_encode($second->getSerializableData()),
         );
     }
 }


### PR DESCRIPTION
Implements #7 (closes #7). Persists the parsed spec across requests so PHP-FPM doesn't re-parse YAML every request.

## Summary

- **`FileSpecSource` gains an optional PSR-16 cache.** Miss → parse + store `json_encode($spec->getSerializableData())`; hit → `Reader::readFromJson` (benchmarked ~15× faster than the YAML parse, and the gap widens for larger specs).
- **mtime-based auto-invalidation.** The cache key is `fissible.accord.spec.file.{xxh32(path)}.{mtime}`, so a redeployed/edited spec produces a new key and is re-parsed — no `cache:clear` needed. `spec_cache_ttl` is a backstop that evicts stale old-mtime entries.
- **Resilient.** Cache get/set failures and invalid-JSON entries fall back to parsing; `json_encode` is guarded; a malformed *local* spec still throws as before.
- **Laravel `spec_cache` config** (`null`/`false`/`''` = off, `true` = default store, string = named store), resolved by the provider and wired into **both** file and URL sources — this also **fixes the previously-dead URL-cache wiring** (the provider used to pass only a TTL to `UrlSpecSource`). `AccordFactory` wires the file cache too.
- Docs: mtime invalidation, plus the long-lived-worker (Octane/RoadRunner) and external-`$ref` caveats.

## Backward compatibility

Fully preserved: the cache defaults to `null` everywhere → identical behavior unless opted in; new `FileSpecSource` ctor params are trailing; `SpecSourceInterface` is unchanged.

## Test Plan

- [x] `vendor/bin/phpunit` — **146 tests pass** (was 137)
- [x] `git diff --check` clean; core stays framework-agnostic (no `Illuminate\` outside `src/Drivers/`)
- [x] Cache miss/hit, invalid-entry fallback, get/set-failure resilience, **mtime invalidation** (temp file + touch + clearstatcache), and **internal-`$ref` round-trip fidelity** all test-covered
- [x] Provider file + url cache wiring test-covered (the url test proves the previously-dead wiring now works)

**Note on deprecations:** the suite reports 8 (was 5). All 8 are `vendor/cebe/php-openapi` PHP-8.4 `resolveReferences` deprecations — the 3 new ones fire only because `tests/Fixtures/v3.yaml` is the first fixture with a `$ref`. None originate from this package's code (verified via `--display-deprecations`).

Design spec + implementation plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)