### PR TITLE
feat: wildcard media types + servers base paths (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,16 @@ For the Slim/Mezzio `AccordFactory`, debug logging requires a logger: pass a PSR
 $middleware = AccordFactory::make(['debug' => true, 'logger' => $psrLogger], $basePath);
 ```
 
+**Path & content-type matching.** Accord matches the request path against your spec's path
+templates as-is first. If nothing matches, it also tries stripping each root-level
+`servers` base path — so a spec with `servers: [{url: /v2}]` and a relative path `/users`
+matches a request to `/v2/users`. (Stripping is segment-safe: `/v20/...` is not treated as
+under `/v2`. Path-item/operation-level `servers` overrides are not considered, and the API
+version must still appear in the request path or be matched by your `version_pattern`.)
+
+Content types are matched exact-first, then by wildcard: a request/response `application/json`
+will match a spec that declares `application/*` or `*/*` (exact declarations always win).
+
 **Per-direction failure modes.** `failure_mode` may be a single value applied to both
 directions, or an array with separate `request` and `response` modes:
 

--- a/docs/superpowers/plans/2026-06-17-wildcard-media-and-server-paths.md
+++ b/docs/superpowers/plans/2026-06-17-wildcard-media-and-server-paths.md
@@ -1,0 +1,600 @@
+# Wildcard Media Types + `servers` Base Paths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop silently skipping operations Accord *should* validate — match wildcard media types (`application/*`, `*/*`) and account for OpenAPI `servers` base paths during operation lookup.
+
+**Architecture:** Two additive changes in `ContractValidator`. (1) A `matchMediaType` helper does exact → `{type}/*` → `*/*` content negotiation in both request and response lookups. (2) Operation lookup becomes method-aware and, when an as-is path doesn't match, retries against the request path with each root-level `servers` base-path prefix stripped (segment-safe); the *effective* matched path is threaded into path-parameter extraction.
+
+**Tech Stack:** PHP 8.2+, PHPUnit 11, cebe/php-openapi, nyholm/psr7.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-wildcard-media-and-server-paths-design.md`
+
+**Branch:** `feat/media-and-server-paths` (already checked out).
+
+**Conventions:** `declare(strict_types=1)`; core stays framework-agnostic (`ContractValidator` is namespace `Fissible\Accord`). Run the suite with `vendor/bin/phpunit --colors=never`. **Baseline: 146 tests passing, 8 deprecations** (all `vendor/cebe` `$ref`/`resolveReferences` noise — the v4/v5/v50 fixtures here have NO `$ref`s, so the count stays 8).
+
+---
+
+## File Structure
+
+**Core (modify):** `src/ContractValidator.php` — `matchMediaType` (new), `serverBasePaths` (new), `matchPathItem` (new), method-aware `findPathItem`/`findOperation`, `validateRequest`/`validateResponse` lookups, `validateParameters` signature.
+
+**Tests (create):** `tests/Fixtures/v4.yaml` (wildcard media), `tests/Fixtures/v5.yaml` (servers base path), `tests/Fixtures/v50.yaml` (segment-safety).
+
+**Tests (modify):** `tests/Feature/ContractValidatorTest.php`.
+
+**Docs (modify):** `README.md`.
+
+---
+
+## Task 1: Wildcard media-type matching
+
+**Files:**
+- Create: `tests/Fixtures/v4.yaml`
+- Modify: `src/ContractValidator.php`
+- Test: `tests/Feature/ContractValidatorTest.php`
+
+- [ ] **Step 1: Create the wildcard fixture** `tests/Fixtures/v4.yaml`:
+
+```yaml
+openapi: '3.0.3'
+info:
+  title: Wildcard Media
+  version: '4'
+paths:
+  /v4/exact-wins:
+    get:
+      operationId: exactWins
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                properties:
+                  id: { type: integer }
+                additionalProperties: false
+            application/*:
+              schema: { type: string }
+  /v4/subtype:
+    get:
+      operationId: subtype
+      responses:
+        '200':
+          description: OK
+          content:
+            application/*:
+              schema:
+                type: object
+                required: [id]
+                properties:
+                  id: { type: integer }
+  /v4/anytype:
+    get:
+      operationId: anytype
+      responses:
+        '200':
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: object
+                required: [id]
+                properties:
+                  id: { type: integer }
+  /v4/exact-only:
+    get:
+      operationId: exactOnly
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { type: object }
+  /v4/upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          application/*:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+      responses:
+        '200':
+          description: OK
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`tests/Feature/ContractValidatorTest.php` (namespace `Fissible\Accord\Tests\Feature`) already imports `SkipReason`, `ContractValidator`, `ServerRequest`, `Response`, etc., and has a `makeValidator()` helper and a `jsonResponse(int $status, string $body, string $type = 'application/json'): Response` helper. Add these methods to the class:
+
+```php
+    public function test_exact_media_type_wins_over_wildcard(): void
+    {
+        // /v4/exact-wins declares application/json (object) AND application/* (string).
+        // A JSON object body is valid for the exact schema, invalid for the wildcard.
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{"id":1}', 'application/json'),
+            new ServerRequest('GET', '/v4/exact-wins'),
+        );
+
+        $this->assertTrue($result->valid);
+        $this->assertTrue($result->wasValidated());
+    }
+
+    public function test_subtype_wildcard_matches_concrete_media_type(): void
+    {
+        // /v4/subtype declares only application/*; a JSON response is validated against it.
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{}', 'application/json'), // missing required id
+            new ServerRequest('GET', '/v4/subtype'),
+        );
+
+        $this->assertFalse($result->valid);
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public function test_full_wildcard_matches_any_media_type(): void
+    {
+        // /v4/anytype declares only */*; even a text/plain response is validated.
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{}', 'text/plain'),
+            new ServerRequest('GET', '/v4/anytype'),
+        );
+
+        $this->assertFalse($result->valid);
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public function test_wildcard_derivation_is_case_insensitive(): void
+    {
+        // Application/JSON (mixed case) → application/* via lowercased derivation.
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{}', 'Application/JSON'),
+            new ServerRequest('GET', '/v4/subtype'),
+        );
+
+        $this->assertFalse($result->valid);
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public function test_unmatched_media_type_still_skips(): void
+    {
+        // /v4/exact-only declares only application/json; text/plain has no wildcard fallback.
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{}', 'text/plain'),
+            new ServerRequest('GET', '/v4/exact-only'),
+        );
+
+        $this->assertSame(SkipReason::UnsupportedMediaType, $result->skipReason);
+    }
+
+    public function test_request_body_wildcard_media_is_matched(): void
+    {
+        // /v4/upload requestBody declares application/*; a JSON body is validated against it.
+        $request = (new ServerRequest('POST', '/v4/upload'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(\Nyholm\Psr7\Stream::create('{}')); // missing required name
+
+        $result = $this->makeValidator()->validateRequest($request);
+
+        $this->assertFalse($result->valid);
+        $this->assertNotEmpty($result->errors);
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter ContractValidatorTest`
+Expected: FAIL — wildcard media types aren't matched (the wildcard ones currently skip `UnsupportedMediaType`, so the invalid-body asserts fail; exact-wins may already pass).
+
+- [ ] **Step 4: Add `matchMediaType` and use it in both lookups**
+
+In `src/ContractValidator.php`:
+
+(a) Add the import after the existing `use cebe\openapi\spec\...` lines (alongside `Operation`, `PathItem`, `Schema`):
+
+```php
+use cebe\openapi\spec\MediaType;
+```
+
+(b) In `validateRequest`, replace the request-body media lookup line:
+
+```php
+            $mediaType   = $operation->requestBody->content[$contentType] ?? null;
+```
+
+with:
+
+```php
+            $mediaType   = $this->matchMediaType($operation->requestBody->content, $contentType);
+```
+
+(c) In `validateResponse`, replace the response media lookup line:
+
+```php
+        $mediaType   = $specResponse->content[$contentType] ?? null;
+```
+
+with:
+
+```php
+        $mediaType   = $this->matchMediaType($specResponse->content, $contentType);
+```
+
+(d) Add the helper method (place it just before `parseContentType`):
+
+```php
+    /** @param array<string, MediaType> $content */
+    private function matchMediaType(array $content, string $contentType): ?MediaType
+    {
+        if (isset($content[$contentType])) {
+            return $content[$contentType];                 // exact (as parsed) wins
+        }
+
+        $lower = strtolower($contentType);
+        $type  = explode('/', $lower)[0];
+
+        return $content[$type . '/*']                      // e.g. application/*
+            ?? $content['*/*']                             // full wildcard
+            ?? null;
+    }
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS. 146 prior + 6 new = 152 tests. Deprecations remain 8 (v4 has no `$ref`s).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ContractValidator.php tests/Feature/ContractValidatorTest.php tests/Fixtures/v4.yaml
+git commit -m "feat: wildcard media-type matching (exact > type/* > */*) for request + response (#10)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `servers` base paths + method-aware lookup + effective-path threading
+
+**Files:**
+- Create: `tests/Fixtures/v5.yaml`, `tests/Fixtures/v50.yaml`
+- Modify: `src/ContractValidator.php`
+- Test: `tests/Feature/ContractValidatorTest.php`
+
+The current relevant methods are: `validateRequest` (computes `$method`, then `$match = $this->findPathItem($spec, $path)`, then `validateParameters($operation, $match['pathItem'], $match['template'], $request)`); `findOperation($spec, $method, $path)` → `findPathItem` → `getOperations()[$method]`; `findPathItem($spec, $path)` (iterates `$spec->paths`, returns `['template','pathItem']`); `validateParameters(Operation, PathItem, string $template, ServerRequestInterface $request)` (calls `extractPathParameters($template, $request->getUri()->getPath())`).
+
+- [ ] **Step 1: Create the fixtures**
+
+`tests/Fixtures/v5.yaml`:
+
+```yaml
+openapi: '3.0.3'
+info:
+  title: Server Base
+  version: '5'
+servers:
+  - url: /v5
+paths:
+  /users:
+    get:
+      operationId: users.index
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: object }
+  /users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer }
+    get:
+      operationId: users.show
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { type: object }
+```
+
+`tests/Fixtures/v50.yaml`:
+
+```yaml
+openapi: '3.0.3'
+info:
+  title: Server Base 50
+  version: '50'
+servers:
+  - url: /v5
+paths:
+  /users:
+    get:
+      operationId: users.index
+      responses:
+        '200':
+          description: OK
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add these methods to `tests/Feature/ContractValidatorTest.php`:
+
+```php
+    public function test_server_base_path_matches_relative_operation(): void
+    {
+        // v5.yaml has servers: [{url: /v5}] and a relative path /users.
+        // Request /v5/users should match after stripping the base — validated, not skipped.
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '[]', 'application/json'),
+            new ServerRequest('GET', '/v5/users'),
+        );
+
+        $this->assertTrue($result->valid);
+        $this->assertTrue($result->wasValidated());
+    }
+
+    public function test_path_params_extracted_on_stripped_route(): void
+    {
+        // /v5/users/5 → strip /v5 → /users/5 against template /users/{id}.
+        // With effective-path threading, id=5 is extracted and validates (integer).
+        // WITHOUT threading, id would be "missing required" and this would be invalid.
+        $result = $this->makeValidator()->validateRequest(new ServerRequest('GET', '/v5/users/5'));
+
+        $this->assertTrue($result->valid);
+        $this->assertTrue($result->wasValidated());
+    }
+
+    public function test_server_base_stripping_is_segment_safe(): void
+    {
+        // /v50/users loads v50.yaml (base /v5). /v5 must NOT be stripped from /v50/... .
+        $result = $this->makeValidator()->validateRequest(new ServerRequest('GET', '/v50/users'));
+
+        $this->assertSame(SkipReason::UnmatchedOperation, $result->skipReason);
+    }
+
+    public function test_full_path_spec_still_matches_as_is(): void
+    {
+        // v1.yaml has no servers; its full-path /v1/users must still match as-is (backward compat).
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '[{"id":1,"name":"a"}]', 'application/json'),
+            new ServerRequest('GET', '/v1/users'),
+        );
+
+        $this->assertTrue($result->valid);
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit --filter ContractValidatorTest`
+Expected: FAIL — `test_server_base_path_matches_relative_operation` and `test_path_params_extracted_on_stripped_route` fail (request `/v5/users` doesn't match the relative `/users` template → `UnmatchedOperation`).
+
+- [ ] **Step 4: Implement method-aware lookup + base-path fallback + threading**
+
+In `src/ContractValidator.php`:
+
+(a) Replace `findOperation` with (passes `$method` to `findPathItem`):
+
+```php
+    private function findOperation(OpenApi $spec, string $method, string $path): ?Operation
+    {
+        $match = $this->findPathItem($spec, $path, $method);
+
+        return $match === null ? null : ($match['pathItem']->getOperations()[$method] ?? null);
+    }
+```
+
+(b) Replace `findPathItem` with the method-aware, base-path-fallback version, and add `matchPathItem` + `serverBasePaths` right after it:
+
+```php
+    /** @return array{template: string, pathItem: PathItem, path: string}|null */
+    private function findPathItem(OpenApi $spec, string $path, string $method): ?array
+    {
+        $match = $this->matchPathItem($spec, $path, $method);   // as-is (current behavior)
+        if ($match !== null) {
+            return $match;
+        }
+
+        foreach ($this->serverBasePaths($spec) as $base) {
+            if ($path === $base || str_starts_with($path, $base . '/')) {
+                $stripped = substr($path, strlen($base));
+                if ($stripped === '') {
+                    $stripped = '/';
+                }
+
+                $match = $this->matchPathItem($spec, $stripped, $method);
+                if ($match !== null) {
+                    return $match;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /** @return array{template: string, pathItem: PathItem, path: string}|null */
+    private function matchPathItem(OpenApi $spec, string $path, string $method): ?array
+    {
+        foreach ($spec->paths as $template => $pathItem) {
+            if (!$pathItem instanceof PathItem || !$this->pathMatches($template, $path)) {
+                continue;
+            }
+
+            if (($pathItem->getOperations()[$method] ?? null) === null) {
+                continue;   // path matches but not this method → keep looking (allow base-path fallback)
+            }
+
+            return ['template' => $template, 'pathItem' => $pathItem, 'path' => $path];
+        }
+
+        return null;
+    }
+
+    /** @return string[] */
+    private function serverBasePaths(OpenApi $spec): array
+    {
+        $bases = [];
+
+        foreach ($spec->servers ?? [] as $server) {
+            $base = rtrim((string) (parse_url($server->url, PHP_URL_PATH) ?? ''), '/');
+
+            if ($base !== '' && $base !== '/') {
+                $bases[$base] = $base;   // dedupe
+            }
+        }
+
+        return array_values($bases);
+    }
+```
+
+(c) In `validateRequest`, change the `findPathItem` call to pass `$method`:
+
+```php
+        $match  = $this->findPathItem($spec, $path, $method);
+```
+
+and change the `validateParameters` call to pass the effective path `$match['path']`:
+
+```php
+        [$paramErrors, $paramsEvaluated] = $this->validateParameters(
+            $operation,
+            $match['pathItem'],
+            $match['template'],
+            $match['path'],
+            $request,
+        );
+```
+
+(d) Change `validateParameters` to accept the effective `$path` and extract path params against it:
+
+```php
+    /** @return array{0: string[], 1: int} */
+    private function validateParameters(
+        Operation $operation,
+        PathItem $pathItem,
+        string $template,
+        string $path,
+        ServerRequestInterface $request,
+    ): array {
+        $errors         = [];
+        $evaluated      = 0;
+        $pathParameters = $this->extractPathParameters($template, $path);
+```
+
+(leave the rest of `validateParameters` — the `foreach` loop and `return [$errors, $evaluated];` — unchanged).
+
+Note: `OpenApi`, `Operation`, `PathItem` are already imported. `parse_url`/`str_starts_with`/`substr`/`rtrim` are builtins. Do not change `pathMatches`, `extractPathParameters`, or any other method.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `vendor/bin/phpunit --colors=never`
+Expected: PASS. 152 prior + 4 new = 156 tests. Deprecations remain 8. All existing operation-matching tests still pass (as-is matching is tried first and is method-aware, preserving prior `UnmatchedOperation` outcomes).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ContractValidator.php tests/Feature/ContractValidatorTest.php tests/Fixtures/v5.yaml tests/Fixtures/v50.yaml
+git commit -m "feat: servers base-path fallback in operation lookup (method-aware, effective-path threading) (#10)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: README documentation
+
+**Files:**
+- Modify: `README.md`
+
+No test (docs).
+
+- [ ] **Step 1: Add a "Path & content-type matching" note**
+
+In `README.md`, find a sensible spot in the spec/validation discussion (e.g. after the "Diagnostics" or near where operation matching / content types are mentioned — grep for `unsupported_media_type` or `unmatched_operation`). Insert this short subsection:
+
+```markdown
+**Path & content-type matching.** Accord matches the request path against your spec's path
+templates as-is first. If nothing matches, it also tries stripping each root-level
+`servers` base path — so a spec with `servers: [{url: /v2}]` and a relative path `/users`
+matches a request to `/v2/users`. (Stripping is segment-safe: `/v20/...` is not treated as
+under `/v2`. Path-item/operation-level `servers` overrides are not considered, and the API
+version must still appear in the request path or be matched by your `version_pattern`.)
+
+Content types are matched exact-first, then by wildcard: a request/response `application/json`
+will match a spec that declares `application/*` or `*/*` (exact declarations always win).
+```
+
+- [ ] **Step 2: Verify suite + fences**
+
+Run: `vendor/bin/phpunit --colors=never` → 156 tests, 8 deprecations.
+Run: `grep -c '```' README.md` → must be EVEN.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document servers base-path and wildcard media-type matching (#10)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Final verification
+
+- [ ] **Step 1: Full suite + clean tree**
+
+```bash
+vendor/bin/phpunit --colors=never
+git diff --check
+```
+Expected: 156 tests pass, 8 deprecations (no new — the new fixtures have no `$ref`s). `git diff --check` prints nothing.
+
+- [ ] **Step 2: Core stayed framework-agnostic**
+
+```bash
+grep -rn 'Illuminate\\' src/ | grep -v src/Drivers/
+```
+Expected: no output.
+
+- [ ] **Step 3: Push + PR (only if the user asks)**
+
+Do not push/PR unless asked. When asked:
+
+```bash
+git push -u origin feat/media-and-server-paths
+gh pr create --title "feat: wildcard media types + servers base paths (#10)" --body "$(cat <<'EOF'
+Implements #10. Stops silently skipping operations Accord should validate.
+
+- **Wildcard media types:** `matchMediaType` negotiates exact → `{type}/*` → `*/*` in both request and response lookups (exact wins; wildcard derivation is case-insensitive).
+- **`servers` base paths:** operation lookup tries the request path as-is, then (method-aware) retries against the path with each root-level `servers` base prefix stripped — segment-safe (`/v20` ≠ under `/v2`). The effective matched path is threaded into path-parameter extraction, so path params on a server-base route extract correctly.
+- Scope: root-level `servers` only; version extraction unchanged.
+
+Backward compatible: as-is path matching and exact media matching are tried first; wildcards/base-paths only add matches that previously surfaced as `unsupported_media_type` / `unmatched_operation` skips. All changes are private to `ContractValidator`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** wildcard matching (exact/subtype/full, both directions, case-insensitive, no-match-skips) → Task 1; serverBasePaths + method-aware findPathItem/matchPathItem + as-is-then-strip + segment-safe + normalize + effective-path threading via validateParameters → Task 2; README → Task 3; framework-agnostic guard → Task 4. The method-aware change (review fix) is in `matchPathItem`; the v50 segment-safety fixture (review fix) is in Task 2.
+- **Type consistency:** `matchMediaType(array, string): ?MediaType`; `findPathItem(OpenApi, string $path, string $method)` and `matchPathItem(...)` both return `array{template,pathItem,path}`; `serverBasePaths(OpenApi): string[]`; `validateParameters(Operation, PathItem, string $template, string $path, ServerRequestInterface)` — `$match['path']` threaded consistently.
+- **No placeholders:** every code step shows the exact old→new lines / full methods; cebe `servers`/wildcard-key access was reality-checked; expected counts cumulative (146→156); deprecation baseline 8 (new fixtures add none).

--- a/docs/superpowers/specs/2026-06-17-wildcard-media-and-server-paths-design.md
+++ b/docs/superpowers/specs/2026-06-17-wildcard-media-and-server-paths-design.md
@@ -1,0 +1,233 @@
+# Wildcard media types + `servers` base paths (#10)
+
+**Date:** 2026-06-17
+**Issue:** #10 (support wildcard media types and OpenAPI `servers` base paths)
+**Package state:** accord is at v1.3.0. This is additive and backward compatible.
+
+## Problem
+
+`ContractValidator` matches operations and content types exactly:
+- A spec declaring `application/*` or `*/*` is silently skipped (`unsupported_media_type`)
+  because the lookup is `content[$contentType] ?? null`.
+- A spec whose `paths` are relative to a `servers` base path (e.g. `servers: [{url: /v2}]`,
+  path `/users`) never matches a request to `/v2/users` — it's a silent
+  `unmatched_operation` skip.
+
+Both now surface as #9 skip reasons, which is what makes them findable — and worth fixing.
+
+## Decisions (confirmed with user)
+
+- **Wildcard media types:** match in precedence order **exact → `{type}/*` → `*/*`**, in both
+  request and response lookups. Exact always wins.
+- **Media type case:** exact lookup uses the parsed content type as-is (first). For wildcard
+  *derivation* the content type is lowercased (HTTP media types are case-insensitive), so
+  `Application/JSON` derives `application/*`.
+- **`servers` base paths:** **additive fallback** — match the request path as-is first
+  (today's behavior, full-path specs unchanged); if no operation matches, strip each server
+  base-path prefix the request path starts with and retry; first match wins.
+- **Segment-safe stripping:** strip a base `B` only when `path === B || str_starts_with(path,
+  B . '/')` — so `/v20/users` is NOT considered under base `/v2`.
+- **Normalize stripped paths:** stripping `/v2` from `/v2/users` → `/users`; from `/v2` → `/`
+  (spec paths need the leading slash).
+- **Scope:** only the root-level `OpenApi::$servers` is read. Path-item-level and
+  operation-level `servers` overrides (which OpenAPI allows) are explicitly **out of scope**.
+  Version extraction is unchanged — the version must still appear in the request path (true
+  when the server base path is the version segment) or via a custom `version_pattern`;
+  non-version base paths like `/api` are out of scope (a `version_pattern` concern).
+
+## Architecture
+
+All changes are in `src/ContractValidator.php` (core, framework-agnostic). No public API
+changes — `findPathItem`'s return shape and `validateParameters`' signature are private.
+
+### Components
+
+1. **`matchMediaType(array $content, string $contentType): ?MediaType`** (new, private) —
+   the content-negotiation helper, replacing the two `content[$contentType] ?? null` lookups:
+   ```php
+   private function matchMediaType(array $content, string $contentType): ?MediaType
+   {
+       if (isset($content[$contentType])) {
+           return $content[$contentType];           // exact (as parsed) wins
+       }
+
+       $lower = strtolower($contentType);
+       $type  = explode('/', $lower)[0];
+
+       return $content[$type . '/*']                 // e.g. application/*
+           ?? $content['*/*']                        // full wildcard
+           ?? null;
+   }
+   ```
+   - Request: `$mediaType = $this->matchMediaType($operation->requestBody->content, $contentType);`
+   - Response: `$mediaType = $this->matchMediaType($specResponse->content, $contentType);`
+   - `$content` values are `MediaType` objects; `MediaType` is `cebe\openapi\spec\MediaType`
+     (add a `use`).
+
+2. **`serverBasePaths(OpenApi $spec): string[]`** (new, private) — collect root-level server
+   base path prefixes:
+   ```php
+   private function serverBasePaths(OpenApi $spec): array
+   {
+       $bases = [];
+       foreach ($spec->servers ?? [] as $server) {
+           $base = rtrim((string) (parse_url($server->url, PHP_URL_PATH) ?? ''), '/');
+           if ($base !== '' && $base !== '/') {
+               $bases[$base] = $base;               // dedupe
+           }
+       }
+       return array_values($bases);
+   }
+   ```
+
+3. **`findPathItem(OpenApi $spec, string $path, string $method): ?array`** (modified) —
+   **method-aware**, as-is then strip; returns the **effective matched path**. Method-aware
+   so that an as-is path template that matches but lacks the requested method does not
+   short-circuit the server-base fallback ("no *operation* matches" → keep trying):
+   ```php
+   private function findPathItem(OpenApi $spec, string $path, string $method): ?array
+   {
+       $match = $this->matchPathItem($spec, $path, $method);   // as-is (current behavior)
+       if ($match !== null) {
+           return $match;
+       }
+
+       foreach ($this->serverBasePaths($spec) as $base) {
+           if ($path === $base || str_starts_with($path, $base . '/')) {
+               $stripped = substr($path, strlen($base));
+               if ($stripped === '') {
+                   $stripped = '/';
+               }
+               $match = $this->matchPathItem($spec, $stripped, $method);
+               if ($match !== null) {
+                   return $match;
+               }
+           }
+       }
+
+       return null;
+   }
+   ```
+
+4. **`matchPathItem(OpenApi $spec, string $path, string $method): ?array`** (new, private) —
+   the extracted current loop, made **method-aware** (a template that matches the path but
+   not the method is skipped, so the caller's base-path fallback still runs) and returning
+   the effective `path`:
+   ```php
+   private function matchPathItem(OpenApi $spec, string $path, string $method): ?array
+   {
+       foreach ($spec->paths as $template => $pathItem) {
+           if (! $pathItem instanceof PathItem || ! $this->pathMatches($template, $path)) {
+               continue;
+           }
+           if (($pathItem->getOperations()[$method] ?? null) === null) {
+               continue;   // path matches but not this method → keep looking (allow base-path fallback)
+           }
+           return ['template' => $template, 'pathItem' => $pathItem, 'path' => $path];
+       }
+       return null;
+   }
+   ```
+   **Note:** `findOperation` (used by `validateResponse`) and `validateRequest` both compute
+   `$method = strtolower($request->getMethod())` and pass it down. In `validateRequest`,
+   because the match is now method-aware, `$match['pathItem']->getOperations()[$method]` is
+   guaranteed non-null when `$match !== null` (the existing defensive `?? null` →
+   `UnmatchedOperation` check is kept but unreachable). `findOperation` passes `$method` to
+   `findPathItem`:
+   ```php
+   private function findOperation(OpenApi $spec, string $method, string $path): ?Operation
+   {
+       $match = $this->findPathItem($spec, $path, $method);
+       return $match === null ? null : ($match['pathItem']->getOperations()[$method] ?? null);
+   }
+   ```
+
+5. **`validateRequest`** (modified) — call `findPathItem` with the method, and pass the
+   effective path to parameter extraction. `$method` is already computed before the lookup:
+   ```php
+   $match = $this->findPathItem($spec, $path, $method);     // now method-aware
+   // ... existing null → UnmatchedOperation, and operation fetch (defensive) ...
+
+   [$paramErrors, $paramsEvaluated] = $this->validateParameters(
+       $operation,
+       $match['pathItem'],
+       $match['template'],
+       $match['path'],          // effective (possibly-stripped) path — NEW
+       $request,
+   );
+   ```
+
+6. **`validateParameters(Operation, PathItem, string $template, string $path, ServerRequestInterface $request): array`**
+   (modified) — extract path params against the effective `$path`, not the raw request URI:
+   ```php
+   $pathParameters = $this->extractPathParameters($template, $path);   // was $request->getUri()->getPath()
+   ```
+   Query and header params still read from `$request` (unaffected by base-path stripping).
+
+`findOperation` (used by `validateResponse`) already delegates to `findPathItem`, so response
+lookup gets the server-base fallback and wildcard matching for free; responses don't extract
+path params, so they need no effective-path threading.
+
+## Data flow (server base `/v2`, spec path `/users/{id}`, request `GET /v2/users/5`)
+
+```
+validateRequest('/v2/users/5')
+  → findPathItem: matchPathItem('/v2/users/5') → no match
+    → base '/v2': '/v2/users/5' starts with '/v2/' → stripped '/users/5'
+    → matchPathItem('/users/5') → template '/users/{id}', path '/users/5'
+  → validateParameters(..., template='/users/{id}', path='/users/5', request)
+    → extractPathParameters('/users/{id}', '/users/5') → {id: '5'}  ✓ (would be empty if raw path used)
+```
+
+## Error handling / backward compatibility
+
+- As-is path matching and exact media match are tried first → existing full-path / exact
+  specs behave identically.
+- Wildcards and base-path stripping only ADD matches that previously skipped
+  (`unsupported_media_type` / `unmatched_operation`).
+- `findPathItem` return-shape (+`path`) and `validateParameters` signature are private — no
+  public API change. `pathMatches`, `extractPathParameters`, etc. unchanged.
+
+## Testing (TDD, one behavior per test)
+
+New fixtures:
+- `tests/Fixtures/v4.yaml` — wildcard media types: an op whose response `200` declares
+  `application/*` (and another path declaring `*/*`); plus a path with a requestBody under a
+  wildcard for the request-side test.
+- `tests/Fixtures/v5.yaml` — `servers: [{url: /v5}]` with **relative** paths `/users` and
+  `/users/{id}` (`id` integer path param). (Version `v5` so VersionExtractor extracts it from
+  `/v5/...`.)
+- `tests/Fixtures/v50.yaml` — needed for the segment-safety test: the default
+  `VersionExtractor` extracts `v50` from `/v50/users`, so without this fixture that request
+  would be `MissingSpec`, not `UnmatchedOperation`. Give it `servers: [{url: /v5}]` and a
+  relative path `/users` (same base as v5). A request `GET /v50/users` then loads `v50.yaml`,
+  and base `/v5` is correctly NOT stripped from `/v50/users` (segment-safe), so it stays
+  `UnmatchedOperation`.
+
+`ContractValidator` tests:
+- exact media type wins over `application/*` (a spec declaring both `application/json` and
+  `application/*` validates a JSON body/response against the exact schema, not the wildcard).
+- `application/*` matches `application/json` (response validated against the wildcard schema).
+- `*/*` matches an arbitrary content type.
+- case-insensitive wildcard derivation: `Application/JSON` matches `application/*`.
+- a content type with no exact and no wildcard match still skips `UnsupportedMediaType`.
+- server-base request `GET /v5/users` matches the relative `/users` op (no longer
+  `UnmatchedOperation`).
+- **path params extract on a stripped route:** `GET /v5/users/5` validates the `id` path
+  param (a bad value → invalid; a good value → validated) — proving effective-path threading.
+- **segment safety:** `GET /v50/users` (loads `v50.yaml`, whose server base is `/v5`) does
+  NOT strip `/v5` from `/v50/users` → stays `UnmatchedOperation` (proves `path === base ||
+  starts_with(path, base.'/')`, not plain `starts_with`).
+- backward compat: an as-is full-path spec (e.g. existing `v1.yaml` `/v1/users`) still matches
+  without any server-base involvement.
+
+Whole suite stays green (currently 146; deprecation baseline 8 from the existing `$ref`
+fixture — adding more fixtures with components/refs may add cebe deprecations, which is
+vendor noise, not our code).
+
+## Out of scope (YAGNI)
+
+- Path-item-level / operation-level `servers` overrides.
+- Making version extraction base-path aware (non-version base paths like `/api`).
+- Parameter-level content (`parameter->content`) wildcard matching.
+- Server `variables` templating in server URLs.

--- a/src/ContractValidator.php
+++ b/src/ContractValidator.php
@@ -54,7 +54,7 @@ class ContractValidator
         }
 
         $method = strtolower($request->getMethod());
-        $match  = $this->findPathItem($spec, $path);
+        $match  = $this->findPathItem($spec, $path, $method);
 
         if ($match === null) {
             return $this->skip(SkipReason::UnmatchedOperation, $version, $request, Direction::Request);
@@ -70,6 +70,7 @@ class ContractValidator
             $operation,
             $match['pathItem'],
             $match['template'],
+            $match['path'],
             $request,
         );
 
@@ -208,25 +209,68 @@ class ContractValidator
 
     private function findOperation(OpenApi $spec, string $method, string $path): ?Operation
     {
-        $match = $this->findPathItem($spec, $path);
+        $match = $this->findPathItem($spec, $path, $method);
 
-        if ($match === null) {
-            return null;
-        }
-
-        return $match['pathItem']->getOperations()[$method] ?? null;
+        return $match === null ? null : ($match['pathItem']->getOperations()[$method] ?? null);
     }
 
-    /** @return array{template: string, pathItem: PathItem}|null */
-    private function findPathItem(OpenApi $spec, string $path): ?array
+    /** @return array{template: string, pathItem: PathItem, path: string}|null */
+    private function findPathItem(OpenApi $spec, string $path, string $method): ?array
     {
-        foreach ($spec->paths as $template => $pathItem) {
-            if ($pathItem instanceof PathItem && $this->pathMatches($template, $path)) {
-                return ['template' => $template, 'pathItem' => $pathItem];
+        $match = $this->matchPathItem($spec, $path, $method);   // as-is (current behavior)
+        if ($match !== null) {
+            return $match;
+        }
+
+        foreach ($this->serverBasePaths($spec) as $base) {
+            if ($path === $base || str_starts_with($path, $base . '/')) {
+                $stripped = substr($path, strlen($base));
+                if ($stripped === '') {
+                    $stripped = '/';
+                }
+
+                $match = $this->matchPathItem($spec, $stripped, $method);
+                if ($match !== null) {
+                    return $match;
+                }
             }
         }
 
         return null;
+    }
+
+    /** @return array{template: string, pathItem: PathItem, path: string}|null */
+    private function matchPathItem(OpenApi $spec, string $path, string $method): ?array
+    {
+        foreach ($spec->paths as $template => $pathItem) {
+            if (!$pathItem instanceof PathItem || !$this->pathMatches($template, $path)) {
+                continue;
+            }
+
+            if (($pathItem->getOperations()[$method] ?? null) === null) {
+                continue;   // path matches but not this method → keep looking (allow base-path fallback)
+            }
+
+            return ['template' => $template, 'pathItem' => $pathItem, 'path' => $path];
+        }
+
+        return null;
+    }
+
+    /** @return string[] */
+    private function serverBasePaths(OpenApi $spec): array
+    {
+        $bases = [];
+
+        foreach ($spec->servers ?? [] as $server) {
+            $base = rtrim((string) (parse_url($server->url, PHP_URL_PATH) ?? ''), '/');
+
+            if ($base !== '' && $base !== '/') {
+                $bases[$base] = $base;   // dedupe
+            }
+        }
+
+        return array_values($bases);
     }
 
     private function pathMatches(string $template, string $path): bool
@@ -248,11 +292,12 @@ class ContractValidator
         Operation $operation,
         PathItem $pathItem,
         string $template,
+        string $path,
         ServerRequestInterface $request,
     ): array {
         $errors         = [];
         $evaluated      = 0;
-        $pathParameters = $this->extractPathParameters($template, $request->getUri()->getPath());
+        $pathParameters = $this->extractPathParameters($template, $path);
 
         foreach ($this->collectParameters($pathItem, $operation) as $parameter) {
             if (!$parameter->schema instanceof Schema || !in_array($parameter->in, ['query', 'path', 'header'], true)) {

--- a/src/ContractValidator.php
+++ b/src/ContractValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fissible\Accord;
 
+use cebe\openapi\spec\MediaType;
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\Parameter;
@@ -77,7 +78,7 @@ class ContractValidator
 
         if ($operation->requestBody !== null) {
             $contentType = $this->parseContentType($request->getHeaderLine('Content-Type'));
-            $mediaType   = $operation->requestBody->content[$contentType] ?? null;
+            $mediaType   = $this->matchMediaType($operation->requestBody->content, $contentType);
 
             if ($mediaType === null) {
                 $bodySkip = SkipReason::UnsupportedMediaType;
@@ -151,7 +152,7 @@ class ContractValidator
         }
 
         $contentType = $this->parseContentType($response->getHeaderLine('Content-Type'));
-        $mediaType   = $specResponse->content[$contentType] ?? null;
+        $mediaType   = $this->matchMediaType($specResponse->content, $contentType);
 
         if ($mediaType === null) {
             return $this->skip(SkipReason::UnsupportedMediaType, $version, $request, Direction::Response);
@@ -465,6 +466,21 @@ class ContractValidator
             fn(array $e) => trim(($e['property'] ? $e['property'] . ': ' : '') . $e['message']),
             $validator->getErrors(),
         );
+    }
+
+    /** @param array<string, MediaType> $content */
+    private function matchMediaType(array $content, string $contentType): ?MediaType
+    {
+        if (isset($content[$contentType])) {
+            return $content[$contentType];                 // exact (as parsed) wins
+        }
+
+        $lower = strtolower($contentType);
+        $type  = explode('/', $lower)[0];
+
+        return $content[$type . '/*']                      // e.g. application/*
+            ?? $content['*/*']                             // full wildcard
+            ?? null;
     }
 
     private function parseContentType(string $header): string

--- a/tests/Feature/ContractValidatorTest.php
+++ b/tests/Feature/ContractValidatorTest.php
@@ -587,6 +587,74 @@ class ContractValidatorTest extends TestCase
         $this->assertCount(0, $logger->records);
     }
 
+    // --- wildcard media-type matching (#10) ---
+
+    public function test_exact_media_type_wins_over_wildcard(): void
+    {
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{"id":1}', 'application/json'),
+            new ServerRequest('GET', '/v4/exact-wins'),
+        );
+
+        $this->assertTrue($result->valid);
+        $this->assertTrue($result->wasValidated());
+    }
+
+    public function test_subtype_wildcard_matches_concrete_media_type(): void
+    {
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{}', 'application/json'),
+            new ServerRequest('GET', '/v4/subtype'),
+        );
+
+        $this->assertFalse($result->valid);
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public function test_full_wildcard_matches_any_media_type(): void
+    {
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{}', 'text/plain'),
+            new ServerRequest('GET', '/v4/anytype'),
+        );
+
+        $this->assertFalse($result->valid);
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public function test_wildcard_derivation_is_case_insensitive(): void
+    {
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{}', 'Application/JSON'),
+            new ServerRequest('GET', '/v4/subtype'),
+        );
+
+        $this->assertFalse($result->valid);
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public function test_unmatched_media_type_still_skips(): void
+    {
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '{}', 'text/plain'),
+            new ServerRequest('GET', '/v4/exact-only'),
+        );
+
+        $this->assertSame(SkipReason::UnsupportedMediaType, $result->skipReason);
+    }
+
+    public function test_request_body_wildcard_media_is_matched(): void
+    {
+        $request = (new ServerRequest('POST', '/v4/upload'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(\Nyholm\Psr7\Stream::create('{}'));
+
+        $result = $this->makeValidator()->validateRequest($request);
+
+        $this->assertFalse($result->valid);
+        $this->assertNotEmpty($result->errors);
+    }
+
     private function makeOptionsValidator(
         RuntimeOptions $options,
         ?RecordingLogger $logger = null,

--- a/tests/Feature/ContractValidatorTest.php
+++ b/tests/Feature/ContractValidatorTest.php
@@ -771,4 +771,46 @@ class ContractValidatorTest extends TestCase
         $this->assertSame('excluded', $logger->records[0]['context']['reason']);
         $this->assertSame('request', $logger->records[0]['context']['direction']);
     }
+
+    // --- servers base-path fallback (#10) ---
+
+    public function test_server_base_path_matches_relative_operation(): void
+    {
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '[]', 'application/json'),
+            new ServerRequest('GET', '/v5/users'),
+        );
+
+        $this->assertTrue($result->valid);
+        $this->assertTrue($result->wasValidated());
+    }
+
+    public function test_path_params_extracted_on_stripped_route(): void
+    {
+        // /v5/users/5 → strip /v5 → /users/5 against /users/{id}; id=5 validates (integer).
+        // Without effective-path threading, id would be "missing required" → invalid.
+        $result = $this->makeValidator()->validateRequest(new ServerRequest('GET', '/v5/users/5'));
+
+        $this->assertTrue($result->valid);
+        $this->assertTrue($result->wasValidated());
+    }
+
+    public function test_server_base_stripping_is_segment_safe(): void
+    {
+        // /v50/users loads v50.yaml (base /v5). /v5 must NOT be stripped from /v50/... .
+        $result = $this->makeValidator()->validateRequest(new ServerRequest('GET', '/v50/users'));
+
+        $this->assertSame(SkipReason::UnmatchedOperation, $result->skipReason);
+    }
+
+    public function test_full_path_spec_still_matches_as_is(): void
+    {
+        // v1.yaml has no servers; its full-path /v1/users must still match as-is.
+        $result = $this->makeValidator()->validateResponse(
+            $this->jsonResponse(200, '[{"id":1,"name":"a"}]', 'application/json'),
+            new ServerRequest('GET', '/v1/users'),
+        );
+
+        $this->assertTrue($result->valid);
+    }
 }

--- a/tests/Fixtures/v4.yaml
+++ b/tests/Fixtures/v4.yaml
@@ -1,0 +1,70 @@
+openapi: '3.0.3'
+info:
+  title: Wildcard Media
+  version: '4'
+paths:
+  /v4/exact-wins:
+    get:
+      operationId: exactWins
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                properties:
+                  id: { type: integer }
+                additionalProperties: false
+            application/*:
+              schema: { type: string }
+  /v4/subtype:
+    get:
+      operationId: subtype
+      responses:
+        '200':
+          description: OK
+          content:
+            application/*:
+              schema:
+                type: object
+                required: [id]
+                properties:
+                  id: { type: integer }
+  /v4/anytype:
+    get:
+      operationId: anytype
+      responses:
+        '200':
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: object
+                required: [id]
+                properties:
+                  id: { type: integer }
+  /v4/exact-only:
+    get:
+      operationId: exactOnly
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { type: object }
+  /v4/upload:
+    post:
+      operationId: upload
+      requestBody:
+        content:
+          application/*:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+      responses:
+        '200':
+          description: OK

--- a/tests/Fixtures/v5.yaml
+++ b/tests/Fixtures/v5.yaml
@@ -1,0 +1,32 @@
+openapi: '3.0.3'
+info:
+  title: Server Base
+  version: '5'
+servers:
+  - url: /v5
+paths:
+  /users:
+    get:
+      operationId: users.index
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: object }
+  /users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer }
+    get:
+      operationId: users.show
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { type: object }

--- a/tests/Fixtures/v50.yaml
+++ b/tests/Fixtures/v50.yaml
@@ -1,0 +1,13 @@
+openapi: '3.0.3'
+info:
+  title: Server Base 50
+  version: '50'
+servers:
+  - url: /v5
+paths:
+  /users:
+    get:
+      operationId: users.index
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Implements #10 (closes #10). Stops silently skipping operations Accord should validate.

## Summary

- **Wildcard media types:** a `matchMediaType` helper negotiates content types **exact → `{type}/*` → `*/*`** in both request and response lookups. Exact always wins; wildcard *derivation* lowercases the content type (HTTP media types are case-insensitive), so `Application/JSON` matches `application/*`.
- **`servers` base paths:** operation lookup tries the request path as-is, then (method-aware) retries against the path with each **root-level** `servers` base prefix stripped — so `servers: [{url: /v2}]` + relative path `/users` matches a request to `/v2/users`. Stripping is **segment-safe** (`/v20` ≠ under `/v2`).
- **Effective-path threading:** the matched (possibly-stripped) path is threaded into path-parameter extraction, so path params on a server-base route (`/v5/users/{id}`) extract correctly instead of falsely reporting "missing required".
- Scope: root-level `servers` only; version extraction unchanged.

## Backward compatibility

Fully preserved: as-is path matching and exact media matching are tried first; wildcards/base-paths only ADD matches that previously surfaced as `unsupported_media_type` / `unmatched_operation` skips. All changes are private to `ContractValidator` — no public API change.

## Test Plan

- [x] `vendor/bin/phpunit` — **156 tests pass** (was 146)
- [x] `git diff --check` clean; core framework-agnostic (no `Illuminate\` outside `src/Drivers/`)
- [x] Exact-beats-wildcard, subtype/full wildcard, case-insensitive derivation, no-match-still-skips, request-body wildcard, server-base relative match, **stripped-route path-param extraction**, segment safety (`/v50` ≠ `/v5`), and as-is backward compat all test-covered

**Deprecations:** the suite reports 8 (pre-existing `vendor/cebe` `$ref` noise from another fixture); the new v4/v5/v50 fixtures have no `$ref`s and add none.

Design spec + implementation plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)